### PR TITLE
Updated audits to make them more searchable

### DIFF
--- a/app/audit/CreateOrAmendDividendsAuditDetail.scala
+++ b/app/audit/CreateOrAmendDividendsAuditDetail.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.{Json, OWrites}
 
 case class CreateOrAmendDividendsAuditDetail(body: Option[DividendsCheckYourAnswersModel],
                                              prior: Option[DividendsPriorSubmission],
+                                             isUpdate: Boolean,
                                              nino: String,
                                              mtditid: String,
                                              userType: String,

--- a/app/audit/CreateOrAmendInterestAuditDetail.scala
+++ b/app/audit/CreateOrAmendInterestAuditDetail.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.{Json, OWrites}
 
 case class CreateOrAmendInterestAuditDetail(body: Option[InterestCYAModel],
                                             prior: Option[InterestPriorSubmission],
+                                            isUpdate: Boolean,
                                             nino: String,
                                             mtditid: String,
                                             userType: String,

--- a/app/controllers/dividends/DividendsCYAController.scala
+++ b/app/controllers/dividends/DividendsCYAController.scala
@@ -96,7 +96,7 @@ class DividendsCYAController @Inject()(
 
     dividendsSubmissionService.submitDividends(cyaData, user.nino, user.mtditid, taxYear).map {
       case Right(DividendsResponseModel(_)) =>
-        auditSubmission(CreateOrAmendDividendsAuditDetail(cyaData, priorData, user.nino, user.mtditid, user.affinityGroup.toLowerCase(), taxYear))
+        auditSubmission(CreateOrAmendDividendsAuditDetail(cyaData, priorData, priorData.isDefined, user.nino, user.mtditid, user.affinityGroup.toLowerCase(), taxYear))
         Redirect(appConfig.incomeTaxSubmissionOverviewUrl(taxYear)).removingFromSession(SessionValues.DIVIDENDS_CYA, SessionValues.DIVIDENDS_PRIOR_SUB)
       case Left(error) => errorHandler.handleError(error.status)
     }

--- a/app/controllers/interest/InterestCYAController.scala
+++ b/app/controllers/interest/InterestCYAController.scala
@@ -80,7 +80,7 @@ class InterestCYAController @Inject()(
     (cyaDataOptional match {
       case Some(cyaData) => interestSubmissionService.submit(cyaData, user.nino, taxYear, user.mtditid).map {
         case response@Right(_) =>
-          val model = CreateOrAmendInterestAuditDetail(Some(cyaData), priorSubmission, user.nino, user.mtditid, user.affinityGroup.toLowerCase, taxYear)
+          val model = CreateOrAmendInterestAuditDetail(Some(cyaData), priorSubmission, priorSubmission.isDefined, user.nino, user.mtditid, user.affinityGroup.toLowerCase, taxYear)
           auditSubmission(model)
           response
         case response => response

--- a/test/audit/CreateOrAmendDividendsAuditDetailSpec.scala
+++ b/test/audit/CreateOrAmendDividendsAuditDetailSpec.scala
@@ -53,13 +53,14 @@ class CreateOrAmendDividendsAuditDetailSpec extends UnitTest {
             "ukDividends" -> 856.23,
             "otherUkDividends" -> 741.12
           ),
+          "isUpdate" -> true,
           "nino" -> "AA123456A",
           "mtditid" -> "1234567890",
           "userType" -> "Individual",
           "taxYear" -> 2020
         )
 
-          val model = CreateOrAmendDividendsAuditDetail(Some(body), Some(prior), nino, mtditid, userType, taxYear)
+          val model = CreateOrAmendDividendsAuditDetail(Some(body), Some(prior), true, nino, mtditid, userType, taxYear)
         Json.toJson(model) shouldBe json
         }
       }

--- a/test/audit/CreateOrAmendInterestAuditDetailSpec.scala
+++ b/test/audit/CreateOrAmendInterestAuditDetailSpec.scala
@@ -82,13 +82,14 @@ class CreateOrAmendInterestAuditDetailSpec extends UnitTest {
              |			"amount": 9001.01
              |		}]
              |	},
+             |  "isUpdate": true,
              |	"nino": "AA123456A",
              |	"mtditid": "1234567890",
              |  "userType": "Individual",
              |	"taxYear": 2020
              |}""".stripMargin)
 
-          val model = CreateOrAmendInterestAuditDetail(Some(body), Some(prior), nino, mtditid, userType, taxYear)
+          val model = CreateOrAmendInterestAuditDetail(Some(body), Some(prior), true, nino, mtditid, userType, taxYear)
         Json.toJson(model) shouldBe json
         }
       }

--- a/test/controllers/dividends/DividendsCYAControllerSpec.scala
+++ b/test/controllers/dividends/DividendsCYAControllerSpec.scala
@@ -301,7 +301,7 @@ class DividendsCYAControllerSpec extends UnitTestWithApp with MockAuditService {
 
       "there is session data " in new TestWithAuth {
         lazy val detail: CreateOrAmendDividendsAuditDetail =
-          CreateOrAmendDividendsAuditDetail(Some(cyaSessionData), Some(priorData), "AA123456A", "1234567890", individualAffinityGroup.toLowerCase(), taxYear)
+          CreateOrAmendDividendsAuditDetail(Some(cyaSessionData), Some(priorData), true, "AA123456A", "1234567890", individualAffinityGroup.toLowerCase(), taxYear)
 
         lazy val event: AuditModel[CreateOrAmendDividendsAuditDetail] =
           AuditModel("CreateOrAmendDividendsUpdate", "createOrAmendDividendsUpdate", detail)

--- a/test/controllers/interest/InterestCYAControllerSpec.scala
+++ b/test/controllers/interest/InterestCYAControllerSpec.scala
@@ -251,7 +251,7 @@ class InterestCYAControllerSpec extends UnitTestWithApp with GivenWhenThen with 
 
         "the submission is successful" in new TestWithAuth {
 
-          lazy val detail: CreateOrAmendInterestAuditDetail = CreateOrAmendInterestAuditDetail(Some(cyaModel), None, "AA123456A", "1234567890", individualAffinityGroup.toLowerCase, taxYear)
+          lazy val detail: CreateOrAmendInterestAuditDetail = CreateOrAmendInterestAuditDetail(Some(cyaModel), None, false, "AA123456A", "1234567890", individualAffinityGroup.toLowerCase, taxYear)
 
           lazy val event: AuditModel[CreateOrAmendInterestAuditDetail] = AuditModel("CreateOrAmendInterestUpdate", "createOrAmendInterestUpdate", detail)
 
@@ -317,7 +317,7 @@ class InterestCYAControllerSpec extends UnitTestWithApp with GivenWhenThen with 
             ))
           )
           lazy val detail: CreateOrAmendInterestAuditDetail = CreateOrAmendInterestAuditDetail(Some(cyaModel),
-            Some(previousSubmission), "AA123456A", "1234567890", agentAffinityGroup.toLowerCase(), taxYear)
+            Some(previousSubmission), true, "AA123456A", "1234567890", agentAffinityGroup.toLowerCase(), taxYear)
 
           lazy val event: AuditModel[CreateOrAmendInterestAuditDetail] = AuditModel("CreateOrAmendInterestUpdate", "createOrAmendInterestUpdate", detail)
 


### PR DESCRIPTION
### Description
PAs needed a searchable field to see if users were returning to update details, or to see if they were making fresh details.
Beforehand the prior field would just not exist for fresh details. This should fix that.

[SASS-657](https://jira.tools.tax.service.gov.uk/browse/SASS-657)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts?
- [x]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [x]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you addressed warnings where appropriate?

##### After PRs been Reviewed
- [x]  Have you checked the PR Builder passes?
- [x]  Have you checked for merge conflicts?
- [x]  Have you checked code coverage isn’t lower than previously?
