### PR TITLE
[SASS-747] - tweaked currency formatter to allow spaces

### DIFF
--- a/app/forms/validation/mappings/Formatters.scala
+++ b/app/forms/validation/mappings/Formatters.scala
@@ -54,6 +54,7 @@ trait Formatters {
           .bind(key, data)
           .right.map(_.replace(",", ""))
           .right.map(_.replace("£", ""))
+          .right.map(_.replaceAll("""\s""", ""))
           .right.flatMap {
           case s if s.isEmpty =>
             Left(Seq(FormError(key, requiredKey, args)))

--- a/test/forms/AmountFormSpec.scala
+++ b/test/forms/AmountFormSpec.scala
@@ -78,13 +78,5 @@ class AmountFormSpec extends UnitTest {
       val bigCurrencyTest = theForm().bind(testInput)
       bigCurrencyTest.errors should contain(FormError(amount, "too big"))
     }
-
-    "remove a leading space from a currency" in {
-      val testInput = Map(amount -> (" " + testCurrencyValid))
-      val expected = testCurrencyValid
-      val leadingSpaceTest = theForm().bind(testInput).value
-      leadingSpaceTest shouldBe Some(expected)
-    }
   }
-
 }

--- a/test/forms/AmountFormSpec.scala
+++ b/test/forms/AmountFormSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import play.api.data.{Form, FormError}
+import utils.UnitTest
+import forms.AmountForm._
+
+class AmountFormSpec extends UnitTest {
+
+  def theForm(): Form[BigDecimal] = {
+    amountForm("nothing to see here", "this not good", "too big")
+  }
+
+  val testCurrencyValid = 1000
+  val testCurrencyWithSpaces = "100 0. 00"
+  val testCurrencyEmpty = ""
+  val testCurrencyInvalidInt = "!"
+  val testCurrencyInvalidFormat = 12345.123
+  val testCurrencyTooBig = "100000000000.00"
+
+  "The AmountForm" should {
+
+    "correctly validate a currency" when {
+
+      "a valid currency is entered" in {
+        val testInput = Map(amount -> testCurrencyValid.toString)
+        val expected = testCurrencyValid
+        val actual = theForm().bind(testInput).value
+        actual shouldBe Some(expected)
+      }
+    }
+
+    "correctly validate a currency with spaces" when {
+
+      "a valid currency is entered" in {
+        val testInput = Map(amount -> testCurrencyWithSpaces.toString)
+        val expected = testCurrencyValid
+        val actual = theForm().bind(testInput).value
+        actual shouldBe Some(expected)
+      }
+    }
+
+    "invalidate an empty currency" in {
+      val testInput = Map(amount -> testCurrencyEmpty)
+      val emptyTest = theForm().bind(testInput)
+      emptyTest.errors should contain(FormError(amount, "nothing to see here"))
+    }
+
+    "invalidate currency that includes invalid characters" in {
+      val testInput = Map(amount -> testCurrencyInvalidInt)
+      val invalidCharTest = theForm().bind(testInput)
+      invalidCharTest.errors should contain(FormError(amount, "this not good"))
+    }
+
+    "invalidate a currency that has incorrect formatting" in {
+      val testInput = Map(amount -> testCurrencyInvalidFormat.toString)
+      val invalidFormatTest = theForm().bind(testInput)
+      invalidFormatTest.errors should contain(FormError(amount, "this not good"))
+    }
+
+    "invalidate a currency that is too big" in {
+      val testInput = Map(amount -> testCurrencyTooBig)
+      val bigCurrencyTest = theForm().bind(testInput)
+      bigCurrencyTest.errors should contain(FormError(amount, "too big"))
+    }
+
+    "remove a leading space from a currency" in {
+      val testInput = Map(amount -> (" " + testCurrencyValid))
+      val expected = testCurrencyValid
+      val leadingSpaceTest = theForm().bind(testInput).value
+      leadingSpaceTest shouldBe Some(expected)
+    }
+  }
+
+}


### PR DESCRIPTION
### Description
Tweaked currency formatter to allow spaces in input.

Add a link to the relevant story in Jira
[SASS-532](https://jira.tools.tax.service.gov.uk/browse/SASS-532)

### Checklist PR Reviewer
##### Before Reviewing
- [ ]  Have you pulled the branch down?
- [ ]  Have you assigned yourself to the PR?
- [ ]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?

##### Whilst Reviewing
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [ ]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [ ]  Have you addressed warnings where appropriate?

##### After PRs been Reviewed
- [ ]  Have you checked the PR Builder passes?
- [ ]  Have you checked for merge conflicts?
- [ ]  Have you checked code coverage isn’t lower than previously?
