### PR TITLE
SASS-1089 - Changed account field in InterestCYAModel to Seq[Interest…

### DIFF
--- a/app/controllers/interest/ChooseAccountController.scala
+++ b/app/controllers/interest/ChooseAccountController.scala
@@ -115,7 +115,7 @@ class ChooseAccountController @Inject()(
 
   private def getPreviousAccounts(cya: Option[InterestCYAModel], prior: Option[InterestPriorSubmission], taxType: String): Set[InterestAccountModel] = {
 
-    val accountsInSession: Seq[InterestAccountModel] = cya.flatMap(_.accounts).getOrElse(Seq())
+    val accountsInSession: Seq[InterestAccountModel] = cya.map(_.accounts).getOrElse(Seq())
     val priorAccounts: Seq[InterestAccountModel] = prior.map(_.submissions).getOrElse(Seq())
 
     if (taxType.equals(UNTAXED)) {

--- a/app/controllers/interest/InterestCYAController.scala
+++ b/app/controllers/interest/InterestCYAController.scala
@@ -22,7 +22,7 @@ import controllers.predicates.AuthorisedAction
 import controllers.predicates.CommonPredicates.commonPredicates
 import controllers.predicates.JourneyFilterAction.journeyFilterAction
 import models.interest.{DecodedInterestSubmissionPayload, InterestCYAModel, InterestPriorSubmission}
-import models.{APIErrorBodyModel, APIErrorModel, User}
+import models.{APIErrorBodyModel, APIErrorModel}
 import play.api.Logging
 import play.api.i18n.I18nSupport
 import play.api.mvc._
@@ -106,7 +106,7 @@ class InterestCYAController @Inject()(
         Some(InterestCYAModel(
           Some(priorData.hasUntaxed),
           Some(priorData.hasTaxed),
-          Some(priorData.submissions.filter(x => x.hasTaxed || x.hasUntaxed))
+          priorData.submissions.filter(x => x.hasTaxed || x.hasUntaxed)
         ))
       case (Some(cyaData), _) => Some(cyaData)
       case _ => None
@@ -123,9 +123,9 @@ class InterestCYAController @Inject()(
   private def handleUnfinishedRedirect(cya: InterestCYAModel, taxYear: Int): Future[Result] = {
     Future(
       cya match {
-        case InterestCYAModel(Some(true), None, None) => Redirect(controllers.interest.routes.ChooseAccountController.show(taxYear, UNTAXED))
-        case InterestCYAModel(Some(false), None, None) => Redirect(controllers.interest.routes.TaxedInterestController.show(taxYear))
-        case InterestCYAModel(Some(true), None, Some(accounts)) if accounts.exists(_.hasUntaxed) =>
+        case InterestCYAModel(Some(true), None, Seq()) => Redirect(controllers.interest.routes.ChooseAccountController.show(taxYear, UNTAXED))
+        case InterestCYAModel(Some(false), None, Seq()) => Redirect(controllers.interest.routes.TaxedInterestController.show(taxYear))
+        case InterestCYAModel(Some(true), None, accounts) if accounts.exists(_.hasUntaxed) =>
           Redirect(controllers.interest.routes.TaxedInterestController.show(taxYear))
         case _ => Redirect(controllers.interest.routes.ChooseAccountController.show(taxYear, TAXED))
       }

--- a/app/controllers/interest/RemoveAccountController.scala
+++ b/app/controllers/interest/RemoveAccountController.scala
@@ -17,7 +17,6 @@
 package controllers.interest
 
 import common.InterestTaxTypes._
-import common.SessionValues
 import config.{AppConfig, ErrorHandler, INTEREST}
 import controllers.predicates.AuthorisedAction
 import controllers.predicates.CommonPredicates.commonPredicates
@@ -28,7 +27,6 @@ import models.interest.{InterestAccountModel, InterestCYAModel, InterestPriorSub
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.I18nSupport
-import play.api.libs.json.Json
 import play.api.mvc._
 import services.InterestSessionService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -75,7 +73,7 @@ class RemoveAccountController @Inject()(
     cya match {
       case Some(cyaData) =>
         cyaData.accounts match {
-          case Some(taxAccounts) if filteredTaxAccounts(taxAccounts, taxType).nonEmpty =>
+          case taxAccounts if filteredTaxAccounts(taxAccounts, taxType).nonEmpty =>
             val accounts = filteredTaxAccounts(taxAccounts, taxType)
             useAccount(accounts, accountId, taxType, taxYear) { account =>
               errorForm.fold(Ok(view(yesNoForm, taxYear, taxType, account, isLastAccount(taxType, prior, accounts)))){
@@ -140,7 +138,7 @@ class RemoveAccountController @Inject()(
                                      )(implicit user: User[_]): Future[Result] = {
 
     cyaData.accounts match {
-      case Some(taxAccounts) if filteredTaxAccounts(taxAccounts, taxType).nonEmpty =>
+      case taxAccounts if filteredTaxAccounts(taxAccounts, taxType).nonEmpty =>
         if (yesNoModel) {
           if (taxType == UNTAXED) {
             handleUntaxedUpdate(taxYear, taxType, cyaData, prior, taxAccounts, accountId)
@@ -173,7 +171,7 @@ class RemoveAccountController @Inject()(
 
     val updatedCyaData = cyaData.copy(
       taxedUkInterest = Some(updatedAccounts.exists(_.hasTaxed)),
-      accounts = Some(updatedAccounts)
+      accounts = updatedAccounts
     )
 
     if (updatedAccounts.exists(_.hasTaxed)) {
@@ -198,7 +196,7 @@ class RemoveAccountController @Inject()(
 
     val updatedCyaData = cyaData.copy(
       untaxedUkInterest = Some(updatedAccounts.exists(_.hasUntaxed)),
-      accounts = Some(updatedAccounts)
+      accounts = updatedAccounts
     )
 
     if (updatedAccounts.exists(_.hasUntaxed)) {

--- a/app/controllers/interest/UntaxedInterestController.scala
+++ b/app/controllers/interest/UntaxedInterestController.scala
@@ -31,7 +31,6 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.ClearingNewCYAAccountsHelper.clearNewEmptyAccounts
 import utils.SessionHelper
 import views.html.interest.UntaxedInterestView
-import java.util.UUID.randomUUID
 
 import common.InterestTaxTypes.UNTAXED
 import javax.inject.Inject
@@ -91,7 +90,7 @@ class UntaxedInterestController @Inject()(
             },
             {
               yesNoModel =>
-                val baseCya = cya.getOrElse(InterestCYAModel(None, None, None))
+                val baseCya = cya.getOrElse(InterestCYAModel(None, None))
                 val updatedCya = baseCya.copy(untaxedUkInterest = Some(yesNoModel), accounts = if (yesNoModel) {
                   baseCya.accounts
                 } else {

--- a/app/models/dividends/DividendsCheckYourAnswersModel.scala
+++ b/app/models/dividends/DividendsCheckYourAnswersModel.scala
@@ -27,8 +27,8 @@ case class DividendsCheckYourAnswersModel(
                                            ukDividends: Option[Boolean] = None,
                                            ukDividendsAmount: Option[BigDecimal] = None,
                                            otherUkDividends: Option[Boolean] = None,
-                                           otherUkDividendsAmount: Option[BigDecimal] = None
-                                    ) {
+                                           otherUkDividendsAmount: Option[BigDecimal] = None) {
+
   def isFinished: Boolean = {
 
     val ukDividendsFinished: Boolean = ukDividends.exists{

--- a/app/models/interest/InterestCYAModel.scala
+++ b/app/models/interest/InterestCYAModel.scala
@@ -91,7 +91,21 @@ case class EncryptedInterestCYAModel(untaxedUkInterest: Option[EncryptedValue] =
 
 object EncryptedInterestCYAModel {
 
-  implicit val formats: OFormat[EncryptedInterestCYAModel] = Json.format[EncryptedInterestCYAModel]
+  implicit val reads: Reads[EncryptedInterestCYAModel] = (
+    (JsPath \ "untaxedUkInterest").readNullable[EncryptedValue] and
+      (JsPath \ "taxedUkInterest").readNullable[EncryptedValue] and
+      (JsPath \ "accounts").readNullable[Seq[EncryptedInterestAccountModel]].map(_.getOrElse(Seq()))
+    ) (EncryptedInterestCYAModel.apply _)
+
+  implicit val writes: Writes[EncryptedInterestCYAModel] = (model: EncryptedInterestCYAModel) => {
+    JsObject(Json.obj(
+      "untaxedUkInterest" -> model.untaxedUkInterest,
+      "taxedUkInterest" -> model.taxedUkInterest,
+      "accounts" -> {
+        if (model.accounts.isEmpty) JsNull else model.accounts
+      }
+    ).fields.filterNot(_._2 == JsNull))
+  }
 
 }
 

--- a/app/services/EncryptionService.scala
+++ b/app/services/EncryptionService.scala
@@ -194,7 +194,7 @@ class EncryptionService @Inject()(encryptionService: SecureGCMCipher, appConfig:
     EncryptedInterestCYAModel(
       interests.untaxedUkInterest.map(x => encryptionService.encrypt[Boolean](x)),
       interests.taxedUkInterest.map(x => encryptionService.encrypt[Boolean](x)),
-      interests.accounts.map(_.map(encryptInterestAccountModel))
+      interests.accounts.map(encryptInterestAccountModel)
     )
   }
 
@@ -203,7 +203,7 @@ class EncryptionService @Inject()(encryptionService: SecureGCMCipher, appConfig:
     InterestCYAModel(
       interests.untaxedUkInterest.map(x => encryptionService.decrypt[Boolean](x.value, x.nonce)),
       interests.taxedUkInterest.map(x => encryptionService.decrypt[Boolean](x.value, x.nonce)),
-      interests.accounts.map(_.map(decryptInterestAccountModel))
+      interests.accounts.map(decryptInterestAccountModel)
     )
   }
 

--- a/app/services/InterestSubmissionService.scala
+++ b/app/services/InterestSubmissionService.scala
@@ -33,12 +33,9 @@ class InterestSubmissionService @Inject()(interestSubmissionConnector: InterestS
   def submit(cyaData: InterestCYAModel, nino: String, taxYear: Int, mtditid: String)
             (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[InterestSubmissionsResponse] = {
 
-    val accounts: Seq[InterestSubmissionModel] = cyaData.accounts.map {
-      _.map {
-        account =>
-          InterestSubmissionModel(account.id, account.accountName, account.untaxedAmount, account.taxedAmount)
-      }
-    }.getOrElse(Seq.empty[InterestSubmissionModel])
+    val accounts: Seq[InterestSubmissionModel] = cyaData.accounts.map { account =>
+      InterestSubmissionModel(account.id, account.accountName, account.untaxedAmount, account.taxedAmount)
+    }
 
     if(accounts.isEmpty){
       logger.info("[InterestSubmissionService][submit] User has entered No & No to both interest questions. Not submitting data to DES.")

--- a/app/utils/ClearingNewCYAAccountsHelper.scala
+++ b/app/utils/ClearingNewCYAAccountsHelper.scala
@@ -20,22 +20,18 @@ import models.interest.{InterestAccountModel, InterestCYAModel}
 
 object ClearingNewCYAAccountsHelper {
 
-  def clearNewEmptyAccounts(cya: InterestCYAModel, untaxed: Boolean): Option[Seq[InterestAccountModel]] = {
+  def clearNewEmptyAccounts(cya: InterestCYAModel, untaxed: Boolean): Seq[InterestAccountModel] = {
 
     val accountsWithRemovedAmounts = if(untaxed){
-      cya.accounts.map(accounts => accounts.map(interestAccountModel => interestAccountModel.copy(untaxedAmount = None)))
+      cya.accounts.map(_.copy(untaxedAmount = None))
     } else {
-      cya.accounts.map(accounts => accounts.map(interestAccountModel => interestAccountModel.copy(taxedAmount = None)))
+      cya.accounts.map(_.copy(taxedAmount = None))
     }
 
     val accountsWithNoAmountsFilteredOut = {
-      accountsWithRemovedAmounts.map(_.filterNot(account => !account.hasUntaxed && !account.hasTaxed))
+      accountsWithRemovedAmounts.filterNot(account => !account.hasUntaxed && !account.hasTaxed)
     }
 
-    if(accountsWithNoAmountsFilteredOut.getOrElse(Seq()).isEmpty){
-      None
-    } else {
-      accountsWithNoAmountsFilteredOut
-    }
+    accountsWithNoAmountsFilteredOut
   }
 }

--- a/app/views/interest/InterestCYAView.scala.html
+++ b/app/views/interest/InterestCYAView.scala.html
@@ -25,23 +25,23 @@
 @import utils.ViewUtils.bigDecimalCurrency
 
 @this(
-    layout: Layout,
-    formWithCSRF: FormWithCSRF,
-    button: Button,
-    heading: Heading,
-    govukSummaryList: GovukSummaryList
+        layout: Layout,
+        formWithCSRF: FormWithCSRF,
+        button: Button,
+        heading: Heading,
+        govukSummaryList: GovukSummaryList
 )
 @(cyaModel: InterestCYAModel, taxYear: Int, priorSubmission: Option[InterestPriorSubmission] = None)(implicit user: User[AnyContent], messages: Messages, appConfig: AppConfig)
 
-@trueFalseToYesNo(input: Boolean) = @{
-    if(input) messages("common.yes") else messages("common.no")
-}
+    @trueFalseToYesNo(input: Boolean) = @{
+        if(input) messages("common.yes") else messages("common.no")
+    }
 
-@details(questionNumber: Int, id: Int, account: InterestAccountModel, amount: BigDecimal) = {
-    <div id="question-@{questionNumber}-account-@{id+1}">@messages("interest.cya.accountDisplay", account.accountName, bigDecimalCurrency(amount.toString))</div>
-}
+    @details(questionNumber: Int, id: Int, account: InterestAccountModel, amount: BigDecimal) = {
+        <div id="question-@{questionNumber}-account-@{id+1}">@messages("interest.cya.accountDisplay", account.accountName, bigDecimalCurrency(amount.toString))</div>
+    }
 
-@accountsInfo(questionNumber: Int, accounts: Seq[InterestAccountModel], untaxed: Boolean) = {
+    @accountsInfo(questionNumber: Int, accounts: Seq[InterestAccountModel], untaxed: Boolean) = {
     @accounts.zipWithIndex.map { case (account, id) =>
 
         @{untaxed match {
@@ -53,55 +53,53 @@
             }
         }}
     }
-}
+    }
 
-@layout(messages(s"interest.cya.title.${if(user.isAgent) "agent" else "individual"}"), taxYear = Some(taxYear), isAgent = user.isAgent) {
+    @layout(messages(s"interest.cya.title.${if(user.isAgent) "agent" else "individual"}"), taxYear = Some(taxYear), isAgent = user.isAgent) {
 
-    @heading(s"interest.cya.title.${if(user.isAgent) "agent" else "individual"}", Some(messages("interest.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-5")
+        @heading(s"interest.cya.title.${if(user.isAgent) "agent" else "individual"}", Some(messages("interest.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-5")
 
-    @{
-        govukSummaryList(SummaryList(Seq(
-            if(!priorSubmission.exists(_.hasUntaxed)) {
-                Some(summaryListRow(
-                    HtmlContent(messages("interest.cya.questions.1")),
-                    HtmlContent(trueFalseToYesNo(cyaModel.untaxedUkInterest.getOrElse(false))),
-                    actions = Seq((controllers.interest.routes.UntaxedInterestController.show(taxYear), messages("common.change"), Some(messages(s"interest.cya.untaxed-uk-interest-accounts.hiddenChange.${if(user.isAgent) "agent" else "individual"}"))))
-                ))
-            } else { None },
-            if(cyaModel.untaxedUkInterest.getOrElse(false)) {
-                cyaModel.accounts.map(_.filter(_.hasUntaxed)).map { accounts =>
-                    summaryListRow(
+        @{
+            govukSummaryList(SummaryList(Seq(
+                if(!priorSubmission.exists(_.hasUntaxed)) {
+                    Some(summaryListRow(
+                        HtmlContent(messages("interest.cya.questions.1")),
+                        HtmlContent(trueFalseToYesNo(cyaModel.untaxedUkInterest.getOrElse(false))),
+                        actions = Seq((controllers.interest.routes.UntaxedInterestController.show(taxYear), messages("common.change"), Some(messages(s"interest.cya.untaxed-uk-interest-accounts.hiddenChange.${if(user.isAgent) "agent" else "individual"}"))))
+                    ))
+                } else { None },
+                if(cyaModel.untaxedUkInterest.getOrElse(false)) {
+                    val accounts = cyaModel.accounts.filter(_.hasUntaxed)
+                    Some(summaryListRow(
                         HtmlContent(messages("interest.cya.questions.2")),
                         HtmlContent(accountsInfo(2, accounts, true)),
                         actions = Seq((controllers.interest.routes.AccountsController.show(taxYear, UNTAXED), messages("common.change"), Some(messages(s"interest.cya.change-untaxed-details.hiddenChange.${if(user.isAgent) "agent" else "individual"}"))))
-                    )
-                }
-            } else { None },
-            if(!priorSubmission.exists(_.hasTaxed)) {
-                Some(summaryListRow(
-                    HtmlContent(messages("interest.cya.questions.3")),
-                    HtmlContent(trueFalseToYesNo(cyaModel.taxedUkInterest.getOrElse(false))),
-                    actions = Seq((controllers.interest.routes.TaxedInterestController.show(taxYear), messages("common.change"), Some(messages(s"interest.cya.taxed-uk-interest-accounts.hiddenChange.${if(user.isAgent) "agent" else "individual"}"))))
-                ))
-            } else { None },
-            if(cyaModel.taxedUkInterest.getOrElse(false)) {
-                cyaModel.accounts.map(_.filter(_.hasTaxed)).map { accounts =>
-                    summaryListRow(
+                    ))
+                } else { None },
+                if(!priorSubmission.exists(_.hasTaxed)) {
+                    Some(summaryListRow(
+                        HtmlContent(messages("interest.cya.questions.3")),
+                        HtmlContent(trueFalseToYesNo(cyaModel.taxedUkInterest.getOrElse(false))),
+                        actions = Seq((controllers.interest.routes.TaxedInterestController.show(taxYear), messages("common.change"), Some(messages(s"interest.cya.taxed-uk-interest-accounts.hiddenChange.${if(user.isAgent) "agent" else "individual"}"))))
+                    ))
+                } else { None },
+                if(cyaModel.taxedUkInterest.getOrElse(false)) {
+                    val accounts = cyaModel.accounts.filter(_.hasTaxed)
+                    Some(summaryListRow(
                         HtmlContent(messages("interest.cya.questions.4")),
                         HtmlContent(accountsInfo(4, accounts, false)),
                         actions = Seq((controllers.interest.routes.AccountsController.show(taxYear, TAXED), messages("common.change"), Some(messages(s"interest.cya.change-taxed-details.hiddenChange.${if(user.isAgent) "agent" else "individual"}"))))
-                    )
-                }
-            } else { None }
-        ).flatten))
+                    ))
+                } else { None }
+            ).flatten))
+        }
+
+
+        @formWithCSRF(action = controllers.interest.routes.InterestCYAController.submit(taxYear)) {
+            @button("common.saveAndContinue", classes = Some("govuk-!-margin-top-6"))
+        }
     }
 
-
-    @formWithCSRF(action = controllers.interest.routes.InterestCYAController.submit(taxYear)) {
-        @button("common.saveAndContinue", classes = Some("govuk-!-margin-top-6"))
+    @{
+        // $COVERAGE-OFF$
     }
-}
-
-@{
-// $COVERAGE-OFF$
-}

--- a/it/controllers/interest/AccountsControllerISpec.scala
+++ b/it/controllers/interest/AccountsControllerISpec.scala
@@ -19,7 +19,6 @@ package controllers.interest
 import common.InterestTaxTypes.{TAXED, UNTAXED}
 import forms.YesNoForm
 import models.interest.{InterestAccountModel, InterestCYAModel}
-import models.mongo.InterestUserDataModel
 import models.priorDataModels.{IncomeSourcesModel, InterestModel}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -185,7 +184,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
             emptyUserDataStub()
             insertCyaData(
               Some(InterestCYAModel(
-                Some(true), Some(false), Some(Seq(InterestAccountModel(None, "Bank of UK", untaxedAmount = Some(9001.00), None, Some("qwerty"))))
+                Some(true), Some(false), Seq(InterestAccountModel(None, "Bank of UK", untaxedAmount = Some(9001.00), None, Some("qwerty")))
               )),taxYear, Some(mtditid), Some(nino)
             )
 
@@ -245,10 +244,10 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
             userDataStub(IncomeSourcesModel(None,Some(Seq(InterestModel("Bank of EU","azerty",None,Some(1234.56))))) ,nino, taxYear)
             insertCyaData(
               Some(InterestCYAModel(
-                Some(true), Some(false), Some(Seq(
+                Some(true), Some(false), Seq(
                   InterestAccountModel(None, "Bank of UK", Some(9000.01), None, Some("qwerty")),
                   InterestAccountModel(Some("azerty"), "Bank of EU",  Some(1234.56), None)
-                ))
+                )
               )),taxYear, Some(mtditid), Some(nino)
             )
 
@@ -363,7 +362,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
             dropInterestDB()
             insertCyaData(
               Some(InterestCYAModel(
-                Some(false), Some(true), Some(Seq(InterestAccountModel(None, "Bank of UK", None, Some(9001.00), Some("qwerty"))))
+                Some(false), Some(true), Seq(InterestAccountModel(None, "Bank of UK", None, Some(9001.00), Some("qwerty")))
               )),taxYear, Some(mtditid), Some(nino)
             )
             emptyUserDataStub()
@@ -423,10 +422,10 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
             userDataStub(IncomeSourcesModel(None,Some(Seq(InterestModel("Bank of EU","azerty",Some(1234.56),None)))) ,nino, taxYear)
             insertCyaData(
               Some(InterestCYAModel(
-                Some(false), Some(true), Some(Seq(
+                Some(false), Some(true), Seq(
                   InterestAccountModel(None, "Bank of UK", None, Some(9000.01), Some("qwerty")),
                   InterestAccountModel(Some("azerty"), "Bank of EU", None, Some(1234.56))
-                ))
+                )
               )),taxYear, Some(mtditid), Some(nino)
             )
 
@@ -542,7 +541,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
           dropInterestDB()
           insertCyaData(
             Some(InterestCYAModel(
-              Some(true), Some(false),Some(Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount), None))),
+              Some(true), Some(false),Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount), None)),
             )),taxYear, Some(mtditid), Some(nino)
           )
 
@@ -559,7 +558,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
         "redirect to the  page when accounts are missing" in {
           dropInterestDB()
           insertCyaData(
-            Some(InterestCYAModel(Some(true), Some(false),None)),taxYear, Some(mtditid), Some(nino)
+            Some(InterestCYAModel(Some(true), Some(false))),taxYear, Some(mtditid), Some(nino)
           )
 
           val result: WSResponse = {
@@ -593,7 +592,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
           dropInterestDB()
           insertCyaData(
             Some(InterestCYAModel(
-              Some(true), None, Some(Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount), None)))
+              Some(true), None, Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount), None))
             )),taxYear, Some(mtditid), Some(nino)
           )
 
@@ -617,7 +616,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
             dropInterestDB()
             emptyUserDataStub()
             insertCyaData(Some(InterestCYAModel(
-              Some(true),  Some(false), Some(Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount)))),
+              Some(true),  Some(false), Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount))),
             )), overrideNino = Some(nino))
 
             authoriseAgentOrIndividual(us.isAgent)
@@ -638,7 +637,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
             emptyUserDataStub()
             insertCyaData(
               Some(InterestCYAModel(
-                Some(true), Some(false), Some(Seq(InterestAccountModel(None, "Untaxed Account", Some(9001.00), None, Some("qwerty"))))
+                Some(true), Some(false), Seq(InterestAccountModel(None, "Untaxed Account", Some(9001.00), None, Some("qwerty")))
               )),taxYear, Some(mtditid), Some(nino)
             )
 
@@ -707,7 +706,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
               insertCyaData(
                 Some(InterestCYAModel(
                   Some(false), Some(true),
-                  Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount))))
+                  Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount)))
                 )),taxYear, Some(mtditid), Some(nino)
               )
 
@@ -724,7 +723,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
       "redirect to the  page when accounts are missing" in {
         dropInterestDB()
         insertCyaData(
-          Some(InterestCYAModel(Some(true), Some(false), None)),
+          Some(InterestCYAModel(Some(true), Some(false))),
           taxYear, Some(mtditid), Some(nino)
         )
 
@@ -761,7 +760,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
             emptyUserDataStub()
             insertCyaData(Some(InterestCYAModel(
               Some(false),
-              Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount))))
+              Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount)))
             )), overrideNino = Some(nino))
 
             authoriseAgentOrIndividual(us.isAgent)
@@ -783,7 +782,7 @@ class AccountsControllerISpec extends IntegrationTest with InterestDatabaseHelpe
             insertCyaData(
               Some(InterestCYAModel(
                 Some(false),
-                Some(true), Some(Seq(InterestAccountModel(None, "Taxed Account", None, Some(amount), Some("qwerty"))))
+                Some(true), Seq(InterestAccountModel(None, "Taxed Account", None, Some(amount), Some("qwerty")))
               )),taxYear, Some(mtditid), Some(nino)
             )
             authoriseAgentOrIndividual(us.isAgent)

--- a/it/controllers/interest/ChangeAccountAmountControllerISpec.scala
+++ b/it/controllers/interest/ChangeAccountAmountControllerISpec.scala
@@ -43,19 +43,19 @@ class ChangeAccountAmountControllerISpec extends IntegrationTest with ViewHelper
   lazy val id: String = UUID.randomUUID().toString
 
   val untaxedInterestCyaModel: InterestCYAModel = InterestCYAModel(
-    Some(true), Some(false), Some(Seq(InterestAccountModel(Some(id), accountName, Some(amount), None)))
+    Some(true), Some(false), Seq(InterestAccountModel(Some(id), accountName, Some(amount), None))
   )
 
   val taxedInterestCyaModel: InterestCYAModel = InterestCYAModel(
-    Some(false), Some(true), Some(Seq(InterestAccountModel(Some(id), accountName, None, Some(amount))))
+    Some(false), Some(true), Seq(InterestAccountModel(Some(id), accountName, None, Some(amount)))
   )
 
   val taxedCyaSubmitModel: InterestCYAModel = InterestCYAModel(
-    Some(false), Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount))))
+    Some(false), Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount)))
   )
 
   val untaxedCyaSubmitModel: InterestCYAModel = InterestCYAModel(
-    Some(true), Some(false), Some(Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount)))),
+    Some(true), Some(false), Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount))),
   )
 
   object Selectors {
@@ -214,10 +214,10 @@ class ChangeAccountAmountControllerISpec extends IntegrationTest with ViewHelper
 
         Seq(
           (InterestCYAModel(
-            Some(true), Some(false), Some(Seq(InterestAccountModel(Some(id), accountName, None, None)))
+            Some(true), Some(false), Seq(InterestAccountModel(Some(id), accountName, None, None))
           ), InterestModel(accountName, id, None, Some(amount)), /*untaxed =*/ true),
           (InterestCYAModel(
-            Some(false), Some(true), Some(Seq(InterestAccountModel(Some(id), accountName, None, None)))
+            Some(false), Some(true), Seq(InterestAccountModel(Some(id), accountName, None, None))
           ), InterestModel(accountName, id, Some(amount), None), /*untaxed =*/ false)
         ) foreach {
           testCase =>
@@ -252,10 +252,10 @@ class ChangeAccountAmountControllerISpec extends IntegrationTest with ViewHelper
 
         Seq(
           (InterestCYAModel(
-            Some(true), Some(false), Some(Seq(InterestAccountModel(Some(id), accountName, Some(differentAmount))))
+            Some(true), Some(false), Seq(InterestAccountModel(Some(id), accountName, Some(differentAmount)))
           ),InterestModel(accountName, id, None, Some(amount)),/*untaxed =*/true),
           (InterestCYAModel(
-            Some(false), Some(true), Some(Seq(InterestAccountModel(Some(id), accountName, None, Some(differentAmount))))
+            Some(false), Some(true), Seq(InterestAccountModel(Some(id), accountName, None, Some(differentAmount)))
           ),InterestModel(accountName, id, Some(amount), None),/*untaxed =*/false)
         ) foreach {
           testCase =>
@@ -279,10 +279,10 @@ class ChangeAccountAmountControllerISpec extends IntegrationTest with ViewHelper
 
         Seq(
           (InterestCYAModel(
-            Some(true), Some(false), Some(Seq(InterestAccountModel(Some(id), accountName)))
+            Some(true), Some(false), Seq(InterestAccountModel(Some(id), accountName))
           ),InterestModel(accountName, id, None, None),/*untaxed =*/true),
           (InterestCYAModel(
-            Some(false), Some(true), Some(Seq(InterestAccountModel(Some(id), accountName)))
+            Some(false), Some(true), Seq(InterestAccountModel(Some(id), accountName))
           ),InterestModel(accountName, id, None, None),/*untaxed =*/false)
         ) foreach {
           testCase =>
@@ -337,10 +337,10 @@ class ChangeAccountAmountControllerISpec extends IntegrationTest with ViewHelper
 
         Seq(
           (InterestCYAModel(
-            Some(true), Some(false), Some(Seq(InterestAccountModel(Some(id), accountName, Some(amount))))
+            Some(true), Some(false), Seq(InterestAccountModel(Some(id), accountName, Some(amount)))
           ),/*untaxed =*/true),
           (InterestCYAModel(
-            Some(false), Some(true), Some(Seq(InterestAccountModel(Some(id), accountName, None, Some(amount))))
+            Some(false), Some(true), Seq(InterestAccountModel(Some(id), accountName, None, Some(amount)))
           ),/*untaxed =*/false)
         ) foreach {
           testCase =>
@@ -408,10 +408,10 @@ class ChangeAccountAmountControllerISpec extends IntegrationTest with ViewHelper
 
         Seq(
           (InterestCYAModel(
-            Some(true), Some(true), Some(Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount),Some(amount)))),
+            Some(true), Some(true), Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount),Some(amount)))
           ), InterestModel(accountName, "UntaxedId",  Some(amount), Some(amount)), /*untaxed =*/ true),
           (InterestCYAModel(
-            Some(true), Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", Some(amount),Some(amount)))),
+            Some(true), Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", Some(amount),Some(amount))),
           ), InterestModel(accountName, "TaxedId", Some(amount),  Some(amount)), /*untaxed =*/ false)
         ) foreach {
           testCase =>
@@ -431,18 +431,18 @@ class ChangeAccountAmountControllerISpec extends IntegrationTest with ViewHelper
                 result.headers("Location").head shouldBe s"/update-and-submit-income-tax-return/personal-income/2022/" +
                   s"interest/accounts-with-${if (testCase._3) "untaxed" else "taxed"}-uk-interest"
                 findInterestDb shouldBe Some(InterestCYAModel(
-                  Some(true),Some(true),Some(Seq(
+                  Some(true),Some(true),Seq(
                     InterestAccountModel(Some(if (testCase._3) "UntaxedId" else "TaxedId"),
                       s"${if (testCase._3) "Untaxed" else "Taxed"} Account",
                       if (testCase._3) Some(45645.99) else Some(25),
-                      if (!testCase._3) Some(45645.99) else Some(25))))))
+                      if (!testCase._3) Some(45645.99) else Some(25)))))
               }
             }
         }
 
         Seq(
-          (InterestCYAModel(Some(true), Some(true), None), InterestModel(accountName, "UntaxedId",  Some(amount), Some(amount)), /*untaxed =*/ true),
-          (InterestCYAModel(Some(true), Some(true), None), InterestModel(accountName, "TaxedId", Some(amount),  Some(amount)), /*untaxed =*/ false)
+          (InterestCYAModel(Some(true), Some(true), Seq()), InterestModel(accountName, "UntaxedId",  Some(amount), Some(amount)), /*untaxed =*/ true),
+          (InterestCYAModel(Some(true), Some(true), Seq()), InterestModel(accountName, "TaxedId", Some(amount),  Some(amount)), /*untaxed =*/ false)
         ) foreach {
           testCase =>
             s"there is no CYA data but there is prior data and input is valid for a ${if (testCase._3) "untaxed" else "taxed"} submission" should {
@@ -461,11 +461,11 @@ class ChangeAccountAmountControllerISpec extends IntegrationTest with ViewHelper
                 result.headers("Location").head shouldBe s"/update-and-submit-income-tax-return/personal-income/2022/" +
                   s"interest/accounts-with-${if (testCase._3) "untaxed" else "taxed"}-uk-interest"
                 findInterestDb shouldBe Some(InterestCYAModel(
-                  Some(true),Some(true),Some(Seq(
+                  Some(true),Some(true),Seq(
                     InterestAccountModel(Some(if (testCase._3) "UntaxedId" else "TaxedId"),
                       accountName,
                       if (testCase._3) Some(45645.99) else Some(25),
-                      if (!testCase._3) Some(45645.99) else Some(25))))))
+                      if (!testCase._3) Some(45645.99) else Some(25)))))
               }
             }
         }
@@ -536,7 +536,7 @@ class ChangeAccountAmountControllerISpec extends IntegrationTest with ViewHelper
                 authoriseAgentOrIndividual(us.isAgent)
                 insertCyaData(Some(testCase._1))
                 userDataStub(IncomeSourcesModel(interest = None), nino, taxYear)
-                urlPost(url(testCase._1.accounts.get.head.id.get, if (testCase._2) "untaxed" else "taxed"),
+                urlPost(url(testCase._1.accounts.head.id.get, if (testCase._2) "untaxed" else "taxed"),
                   Map("" -> ""),
                   us.isWelsh, follow = false, playSessionCookie(us.isAgent))
               }

--- a/it/controllers/interest/ChooseAccountControllerISpec.scala
+++ b/it/controllers/interest/ChooseAccountControllerISpec.scala
@@ -229,7 +229,7 @@ class ChooseAccountControllerISpec extends IntegrationTest with ViewHelpers with
             dropInterestDB()
             emptyUserDataStub()
             userDataStub(IncomeSourcesModel(interest = Some(accounts)), nino, taxYear)
-            insertCyaData(Some(InterestCYAModel(accounts = Some(accounts2), taxedUkInterest = Some(true))))
+            insertCyaData(Some(InterestCYAModel(accounts = accounts2, taxedUkInterest = Some(true))))
             urlGet(chooseAccountUrl(TAXED), us.isWelsh, headers = playSessionCookie(us.isAgent))
           }
 
@@ -297,7 +297,7 @@ class ChooseAccountControllerISpec extends IntegrationTest with ViewHelpers with
             dropInterestDB()
             emptyUserDataStub()
             userDataStub(IncomeSourcesModel(interest = Some(accounts)), nino, taxYear)
-            insertCyaData(Some(InterestCYAModel(accounts = Some(accounts2), untaxedUkInterest = Some(true))))
+            insertCyaData(Some(InterestCYAModel(accounts = accounts2, untaxedUkInterest = Some(true))))
             urlGet(chooseAccountUrl(UNTAXED), us.isWelsh, headers = playSessionCookie(us.isAgent))
           }
 
@@ -526,7 +526,7 @@ class ChooseAccountControllerISpec extends IntegrationTest with ViewHelpers with
               dropInterestDB()
               emptyUserDataStub()
               userDataStub(IncomeSourcesModel(interest = Some(accounts)), nino, taxYear)
-              insertCyaData(Some(InterestCYAModel(accounts = Some(accounts2), taxedUkInterest = Some(true))))
+              insertCyaData(Some(InterestCYAModel(accounts = accounts2, taxedUkInterest = Some(true))))
               urlPost(chooseAccountUrl(TAXED), body = Map[String, String](), us.isWelsh, headers = playSessionCookie(us.isAgent))
             }
 
@@ -556,7 +556,7 @@ class ChooseAccountControllerISpec extends IntegrationTest with ViewHelpers with
               dropInterestDB()
               emptyUserDataStub()
               userDataStub(IncomeSourcesModel(interest = Some(accounts)), nino, taxYear)
-              insertCyaData(Some(InterestCYAModel(accounts = Some(accounts2), untaxedUkInterest = Some(true))))
+              insertCyaData(Some(InterestCYAModel(accounts = accounts2, untaxedUkInterest = Some(true))))
               urlPost(chooseAccountUrl(UNTAXED), body = Map[String, String](), us.isWelsh, headers = playSessionCookie(us.isAgent))
             }
 
@@ -591,7 +591,7 @@ class ChooseAccountControllerISpec extends IntegrationTest with ViewHelpers with
           dropInterestDB()
           emptyUserDataStub()
           userDataStub(IncomeSourcesModel(interest = Some(accounts)), nino, taxYear)
-          insertCyaData(Some(InterestCYAModel(accounts = Some(accounts2), taxedUkInterest = Some(true))))
+          insertCyaData(Some(InterestCYAModel(accounts = accounts2, taxedUkInterest = Some(true))))
           urlPost(chooseAccountUrl(TAXED), follow = false, body =
             Map(AccountList.accountName -> SessionValues.ADD_A_NEW_ACCOUNT), headers = playSessionCookie())
         }
@@ -610,7 +610,7 @@ class ChooseAccountControllerISpec extends IntegrationTest with ViewHelpers with
           dropInterestDB()
           emptyUserDataStub()
           userDataStub(IncomeSourcesModel(interest = Some(accounts)), nino, taxYear)
-          insertCyaData(Some(InterestCYAModel(accounts = Some(accounts2), untaxedUkInterest = Some(true))))
+          insertCyaData(Some(InterestCYAModel(accounts = accounts2, untaxedUkInterest = Some(true))))
           urlPost(chooseAccountUrl(UNTAXED), follow = false, body =
             Map(AccountList.accountName -> SessionValues.ADD_A_NEW_ACCOUNT), headers = playSessionCookie())
         }
@@ -629,7 +629,7 @@ class ChooseAccountControllerISpec extends IntegrationTest with ViewHelpers with
           dropInterestDB()
           emptyUserDataStub()
           userDataStub(IncomeSourcesModel(interest = Some(accounts)), nino, taxYear)
-          insertCyaData(Some(InterestCYAModel(accounts = Some(accounts2), taxedUkInterest = Some(true))))
+          insertCyaData(Some(InterestCYAModel(accounts = accounts2, taxedUkInterest = Some(true))))
           urlPost(chooseAccountUrl(TAXED), follow = false, body =
             Map(AccountList.accountName -> sessionId1), headers = playSessionCookie())
         }
@@ -649,7 +649,7 @@ class ChooseAccountControllerISpec extends IntegrationTest with ViewHelpers with
           dropInterestDB()
           emptyUserDataStub()
           userDataStub(IncomeSourcesModel(interest = Some(accounts)), nino, taxYear)
-          insertCyaData(Some(InterestCYAModel(accounts = Some(accounts2), untaxedUkInterest = Some(true))))
+          insertCyaData(Some(InterestCYAModel(accounts = accounts2, untaxedUkInterest = Some(true))))
           urlPost(chooseAccountUrl(UNTAXED), follow = false, body =
             Map(AccountList.accountName -> "1"), headers = playSessionCookie())
         }

--- a/it/controllers/interest/InterestCYAControllerISpec.scala
+++ b/it/controllers/interest/InterestCYAControllerISpec.scala
@@ -264,9 +264,7 @@ class InterestCYAControllerISpec extends IntegrationTest with InterestDatabaseHe
         "only has the untaxedUkInterest questions answered" which {
           val cyaModel = InterestCYAModel(
             untaxedUkInterest = Some(true),
-            accounts = Some(Seq(
-              InterestAccountModel(Some("id"), "UntaxedBank1", Some(100.00))
-            ))
+            accounts = Seq(InterestAccountModel(Some("id"), "UntaxedBank1", Some(100.00)))
           )
 
           lazy val result = {
@@ -308,11 +306,11 @@ class InterestCYAControllerISpec extends IntegrationTest with InterestDatabaseHe
           val cyaModel = InterestCYAModel(
             untaxedUkInterest = Some(true),
             taxedUkInterest = Some(true),
-            accounts = Some(Seq(
+            accounts = Seq(
               InterestAccountModel(Some("id"), "UntaxedBank1", Some(100.00)),
               InterestAccountModel(Some("id2"), "TaxedBank1", None, Some(200.00)),
               InterestAccountModel(Some("id3"), "TaxedBank2", None, Some(400.00))
-            ))
+            )
           )
 
           lazy val result = {
@@ -426,9 +424,9 @@ class InterestCYAControllerISpec extends IntegrationTest with InterestDatabaseHe
             val cyaModel = InterestCYAModel(
               untaxedUkInterest = Some(true),
               taxedUkInterest = Some(true),
-              accounts = Some(Seq(
+              accounts = Seq(
                 InterestAccountModel(Some("qwerty"), "TSB", Some(100.00)),
-                InterestAccountModel(Some("azerty"), "TSB Account", None, Some(100.00))))
+                InterestAccountModel(Some("azerty"), "TSB Account", None, Some(100.00)))
             )
 
             lazy val result = {
@@ -525,7 +523,7 @@ class InterestCYAControllerISpec extends IntegrationTest with InterestDatabaseHe
             dropInterestDB()
             emptyUserDataStub()
             insertCyaData(Some(InterestCYAModel(
-              Some(false), Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount))))
+              Some(false), Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount)))
             )), taxYear, Some(mtditid), None)
             authoriseIndividual()
             stubGet(s"/update-and-submit-income-tax-return/$taxYear/view", OK, "")
@@ -556,7 +554,7 @@ class InterestCYAControllerISpec extends IntegrationTest with InterestDatabaseHe
             emptyUserDataStub()
             insertCyaData(Some(InterestCYAModel(
               Some(false),
-              Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount))))
+              Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount)))
             )))
             authoriseIndividual(None)
             urlPost(s"$appUrl/$taxYear/interest/check-interest", "{}", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -571,7 +569,7 @@ class InterestCYAControllerISpec extends IntegrationTest with InterestDatabaseHe
             emptyUserDataStub()
             insertCyaData(Some(InterestCYAModel(
               Some(false),
-              Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount))))
+              Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(amount)))
             )))
             authoriseIndividualUnauthorized()
             urlPost(s"$appUrl/$taxYear/interest/check-interest", "{}", us.isWelsh, follow = true, playSessionCookie(us.isAgent))

--- a/it/controllers/interest/RemoveAccountControllerISpec.scala
+++ b/it/controllers/interest/RemoveAccountControllerISpec.scala
@@ -134,7 +134,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
                   dropInterestDB()
                   emptyUserDataStub()
                   insertCyaData(Some(InterestCYAModel(
-                    Some(true), Some(false),Some(Seq(untaxedInterestAccount, untaxedInterestAccount2)),
+                    Some(true), Some(false), Seq(untaxedInterestAccount, untaxedInterestAccount2),
                   )))
                   authoriseAgentOrIndividual(us.isAgent)
                   urlGet(s"$appUrl/$taxYear/interest/remove-untaxed-interest-account?accountId=UntaxedId", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -161,7 +161,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
                   dropInterestDB()
                   userDataStub(IncomeSourcesModel(None, Some(Seq(InterestModel("firstAccountName", "Id", Some(123), Some(123)))), None), nino, taxYear)
                   insertCyaData(Some(InterestCYAModel(
-                    Some(true), Some(true),Some(Seq(untaxedInterestAccount, taxedInterestAccount)),
+                    Some(true), Some(true), Seq(untaxedInterestAccount, taxedInterestAccount),
                   )))
                   authoriseAgentOrIndividual(us.isAgent)
                   urlGet(s"$appUrl/$taxYear/interest/remove-untaxed-interest-account?accountId=UntaxedId", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -188,7 +188,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
                   dropInterestDB()
                   userDataStub(IncomeSourcesModel(None, Some(Seq(InterestModel("firstAccountName", "Id", Some(123), Some(123)))), None), nino, taxYear)
                   insertCyaData(Some(InterestCYAModel(
-                    Some(true), Some(true),Some(Seq(untaxedInterestAccount, taxedInterestAccount)),
+                    Some(true), Some(true), Seq(untaxedInterestAccount, taxedInterestAccount),
                   )))
                   authoriseAgentOrIndividual(us.isAgent)
                   urlGet(s"$appUrl/$taxYear/interest/remove-taxed-interest-account?accountId=TaxedId", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -215,7 +215,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
                   dropInterestDB()
                   emptyUserDataStub()
                   insertCyaData(Some(InterestCYAModel(
-                    Some(true), Some(false),Some(Seq(untaxedInterestAccount))
+                    Some(true), Some(false), Seq(untaxedInterestAccount)
                   )))
                   authoriseAgentOrIndividual(us.isAgent)
                   urlGet(s"$appUrl/$taxYear/interest/remove-untaxed-interest-account?accountId=UntaxedId", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -266,7 +266,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               dropInterestDB()
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
-                Some(true), Some(false),Some(Seq(taxedInterestAccount))
+                Some(true), Some(false), Seq(taxedInterestAccount)
               )))
               authoriseAgentOrIndividual(us.isAgent)
               urlGet(s"$appUrl/$taxYear/interest/remove-untaxed-interest-account?accountId=UntaxedId", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -286,7 +286,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               dropInterestDB()
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
-                Some(true), Some(false),Some(Seq(untaxedInterestAccount))
+                Some(true), Some(false), Seq(untaxedInterestAccount)
               )))
               authoriseAgentOrIndividual(us.isAgent)
               urlGet(s"$appUrl/$taxYear/interest/remove-untaxed-interest-account?accountId=UntaxedId2", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -305,7 +305,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               dropInterestDB()
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
-                Some(false), Some(true),Some(Seq(untaxedInterestAccount))
+                Some(false), Some(true), Seq(untaxedInterestAccount)
               )))
               authoriseAgentOrIndividual(us.isAgent)
               urlGet(s"$appUrl/$taxYear/interest/remove-taxed-interest-account?accountId=UntaxedId", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -381,7 +381,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
                   dropInterestDB()
                   emptyUserDataStub()
                   insertCyaData(Some(InterestCYAModel(
-                    Some(false), Some(true), Some(Seq(taxedInterestAccount, taxedInterestAccount2)),
+                    Some(false), Some(true), Seq(taxedInterestAccount, taxedInterestAccount2),
                   )))
                   authoriseAgentOrIndividual(us.isAgent)
                   urlGet(s"$appUrl/$taxYear/interest/remove-taxed-interest-account?accountId=TaxedId", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -408,7 +408,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
                   dropInterestDB()
                   emptyUserDataStub()
                   insertCyaData(Some(InterestCYAModel(
-                    Some(false), Some(true), Some(Seq(taxedInterestAccount)),
+                    Some(false), Some(true), Seq(taxedInterestAccount),
                   )))
                   authoriseAgentOrIndividual(us.isAgent)
                   urlGet(s"$appUrl/$taxYear/interest/remove-taxed-interest-account?accountId=TaxedId", us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -490,7 +490,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               dropInterestDB()
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
-                Some(true), Some(true), Some(Seq(untaxedInterestAccount,taxedInterestAccount)),
+                Some(true), Some(true), Seq(untaxedInterestAccount,taxedInterestAccount),
               )))
               authoriseAgentOrIndividual(us.isAgent)
 
@@ -511,7 +511,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               dropInterestDB()
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
-                Some(true), Some(true), Some(Seq(untaxedInterestAccount,taxedInterestAccount)),
+                Some(true), Some(true), Seq(untaxedInterestAccount,taxedInterestAccount),
               )))
               authoriseAgentOrIndividual(us.isAgent)
 
@@ -532,7 +532,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               dropInterestDB()
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
-                Some(true), Some(true), Some(Seq(untaxedInterestAccount.copy(taxedAmount = Some(55)),taxedInterestAccount.copy(untaxedAmount = Some(55)))),
+                Some(true), Some(true), Seq(untaxedInterestAccount.copy(taxedAmount = Some(55)),taxedInterestAccount.copy(untaxedAmount = Some(55))),
               )))
               authoriseAgentOrIndividual(us.isAgent)
 
@@ -553,7 +553,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               dropInterestDB()
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
-                Some(true), Some(true), Some(Seq(untaxedInterestAccount.copy(taxedAmount = Some(55)),taxedInterestAccount.copy(untaxedAmount = Some(55)))),
+                Some(true), Some(true), Seq(untaxedInterestAccount.copy(taxedAmount = Some(55)),taxedInterestAccount.copy(untaxedAmount = Some(55))),
               )))
               authoriseAgentOrIndividual(us.isAgent)
 
@@ -577,7 +577,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               dropInterestDB()
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
-                Some(true), Some(true), Some(Seq(untaxedInterestAccount,taxedInterestAccount)),
+                Some(true), Some(true), Seq(untaxedInterestAccount,taxedInterestAccount),
               )))
               authoriseAgentOrIndividual(us.isAgent)
 
@@ -598,7 +598,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               dropInterestDB()
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
-                Some(true), Some(true), Some(Seq(taxedInterestAccount)),
+                Some(true), Some(true), Seq(taxedInterestAccount),
               )))
               authoriseAgentOrIndividual(us.isAgent)
 
@@ -671,7 +671,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
                 Some(true),
-                Some(true), Some(Seq(taxedInterestAccount, untaxedInterestAccount))
+                Some(true), Seq(taxedInterestAccount, untaxedInterestAccount)
               )))
               authoriseAgentOrIndividual(us.isAgent)
 
@@ -759,7 +759,7 @@ class RemoveAccountControllerISpec extends IntegrationTest with InterestDatabase
               emptyUserDataStub()
               insertCyaData(Some(InterestCYAModel(
                 Some(true),
-                Some(true), Some(Seq(untaxedInterestAccount, taxedInterestAccount))
+                Some(true), Seq(untaxedInterestAccount, taxedInterestAccount)
               )))
               authoriseAgentOrIndividual(us.isAgent)
 

--- a/it/controllers/interest/TaxedInterestAmountControllerISpec.scala
+++ b/it/controllers/interest/TaxedInterestAmountControllerISpec.scala
@@ -151,11 +151,11 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
             dropInterestDB()
             emptyUserDataStub()
             insertCyaData(Some(InterestCYAModel(
-              Some(false), Some(true), Some(Seq(
+              Some(false), Some(true), Seq(
                 InterestAccountModel(Some("differentId"), firstAccountName, taxedAmount = Some(amount)),
                 InterestAccountModel(None, secondAccountName, taxedAmount = Some(amount), uniqueSessionId = Some(id))
               ))
-            )))
+            ))
             authoriseAgentOrIndividual(us.isAgent)
             urlGet(url(id), us.isWelsh, follow = false, playSessionCookie(us.isAgent))
           }
@@ -187,7 +187,7 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
           lazy val result = {
             dropInterestDB()
             emptyUserDataStub()
-            insertCyaData(Some(InterestCYAModel(Some(false), Some(true), None)))
+            insertCyaData(Some(InterestCYAModel(Some(false), Some(true))))
             authoriseAgentOrIndividual(us.isAgent)
             urlGet(url("id"), us.isWelsh, follow = false, playSessionCookie(us.isAgent))
           }
@@ -207,7 +207,7 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
               userDataStub(IncomeSourcesModel(None, Some(Seq(InterestModel(firstAccountName, id, None, Some(amount)))), None), nino, taxYear)
               insertCyaData(Some(InterestCYAModel(
                 Some(false), Some(true),
-                Some(Seq(InterestAccountModel(Some(id), firstAccountName, taxedAmount = Some(amount), uniqueSessionId= Some(id))))
+                Seq(InterestAccountModel(Some(id), firstAccountName, taxedAmount = Some(amount), uniqueSessionId= Some(id)))
               )), taxYear, None, Some(nino))
               authoriseAgentOrIndividual(us.isAgent)
               urlGet(url(id), us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -273,11 +273,11 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
           dropInterestDB()
           emptyUserDataStub()
           insertCyaData(Some(InterestCYAModel(
-            Some(false), Some(true), Some(Seq(
+            Some(false), Some(true), Seq(
               InterestAccountModel(Some("differentId"), firstAccountName, taxedAmount =  Some(amount)),
               InterestAccountModel(None, secondAccountName, taxedAmount = Some(amount), uniqueSessionId = Some(id))
             ))
-          )))
+          ))
           authoriseAgentOrIndividual(us.isAgent)
           urlPost(url(id), formMap, us.isWelsh, follow = false, playSessionCookie(us.isAgent))
         }
@@ -387,10 +387,10 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
             dropInterestDB()
             emptyUserDataStub()
             insertCyaData(Some(InterestCYAModel(
-              Some(false), Some(true), Some(Seq(
+              Some(false), Some(true), Seq(
                 InterestAccountModel(Some("differentId"), firstAccountName, taxedAmount = Some(amount)),
                 InterestAccountModel(None, secondAccountName, taxedAmount = Some(amount), uniqueSessionId = Some(id))
-              ))
+              )
             )))
             authoriseAgentOrIndividual(us.isAgent)
             urlPost(url("1234567890-09876543210"), Map(
@@ -438,9 +438,9 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
           lazy val result: WSResponse = {
             dropInterestDB()
             userDataStub(IncomeSourcesModel(None, Some(Seq(InterestModel(firstAccountName, id, None, None))), None), nino, taxYear)
-            insertCyaData(Some(InterestCYAModel(None,Some(true),Some(Seq(
+            insertCyaData(Some(InterestCYAModel(None,Some(true),Seq(
               InterestAccountModel(None,"name",taxedAmount = Some(1234),uniqueSessionId = Some("1234567890"))
-            )))))
+            ))))
             authoriseAgentOrIndividual(us.isAgent)
             urlPost(url("1234567890"), Map(
               TaxedInterestAmountForm.taxedAmount -> "12,344.98",
@@ -460,9 +460,9 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
           lazy val result: WSResponse = {
             dropInterestDB()
             emptyUserDataStub()
-            insertCyaData(Some(InterestCYAModel(None,Some(true),Some(Seq(
+            insertCyaData(Some(InterestCYAModel(None,Some(true),Seq(
               InterestAccountModel(None,"name",Some(1234),Some(1234),uniqueSessionId = Some("1234567890"))
-            )))))
+            ))))
             authoriseAgentOrIndividual(us.isAgent)
             urlPost(url("1234567890"), Map(
               TaxedInterestAmountForm.taxedAmount -> "12,344.98",
@@ -476,10 +476,10 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
               "/update-and-submit-income-tax-return/personal-income/2022/interest/accounts-with-taxed-uk-interest")
 
             val data = findInterestDb
-            data.head shouldBe InterestCYAModel(None,Some(true),Some(Seq(
-              InterestAccountModel(None,firstAccountName,taxedAmount = Some(12344.98),uniqueSessionId = data.head.accounts.get.head.uniqueSessionId),
+            data.head shouldBe InterestCYAModel(None,Some(true),Seq(
+              InterestAccountModel(None,firstAccountName,taxedAmount = Some(12344.98),uniqueSessionId = data.head.accounts.head.uniqueSessionId),
               InterestAccountModel(None,"name",Some(1234),None,uniqueSessionId = Some("1234567890"))
-            )))
+            ))
           }
         }
 
@@ -502,9 +502,9 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
               "/update-and-submit-income-tax-return/personal-income/2022/interest/accounts-with-taxed-uk-interest")
 
             val data = findInterestDb
-            data.head shouldBe InterestCYAModel(None,Some(true),Some(List(
-              InterestAccountModel(None,firstAccountName,taxedAmount = Some(12344.98),uniqueSessionId = data.head.accounts.get.head.uniqueSessionId)
-            )))
+            data.head shouldBe InterestCYAModel(None,Some(true),List(
+              InterestAccountModel(None,firstAccountName,taxedAmount = Some(12344.98),uniqueSessionId = data.head.accounts.head.uniqueSessionId)
+            ))
           }
         }
 

--- a/it/controllers/interest/TaxedInterestControllerISpec.scala
+++ b/it/controllers/interest/TaxedInterestControllerISpec.scala
@@ -147,7 +147,7 @@ class TaxedInterestControllerISpec extends IntegrationTest with InterestDatabase
 
             val interestCYA = InterestCYAModel(
               Some(false),
-              Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00))))
+              Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00)))
             )
 
             lazy val result: WSResponse = {
@@ -262,7 +262,7 @@ class TaxedInterestControllerISpec extends IntegrationTest with InterestDatabase
           lazy val result: WSResponse = {
             val interestCYA = InterestCYAModel(
               Some(false),
-              Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00))))
+              Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00)))
             )
 
             dropInterestDB()
@@ -287,7 +287,7 @@ class TaxedInterestControllerISpec extends IntegrationTest with InterestDatabase
             lazy val result: WSResponse = {
               val interestCYA = InterestCYAModel(
                 Some(false),
-                Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00))))
+                Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00)))
               )
 
               dropInterestDB()
@@ -332,7 +332,7 @@ class TaxedInterestControllerISpec extends IntegrationTest with InterestDatabase
             lazy val result: WSResponse = {
               val interestCYA = InterestCYAModel(
                 Some(false),
-                Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00))))
+                Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00)))
               )
 
               dropInterestDB()
@@ -353,7 +353,7 @@ class TaxedInterestControllerISpec extends IntegrationTest with InterestDatabase
           "the yes/no radio button has not been selected" which {
             val interestCYA = InterestCYAModel(
               Some(false),
-              Some(true), Some(Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00))))
+              Some(true), Seq(InterestAccountModel(Some("TaxedId"), "Taxed Account", None, Some(25.00)))
             )
 
             lazy val result: WSResponse = {

--- a/it/controllers/interest/UntaxedInterestAmountControllerISpec.scala
+++ b/it/controllers/interest/UntaxedInterestAmountControllerISpec.scala
@@ -151,11 +151,11 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
             dropInterestDB()
             emptyUserDataStub()
             insertCyaData(Some(InterestCYAModel(
-              Some(true), Some(false), Some(Seq(
+              Some(true), Some(false), Seq(
                 InterestAccountModel(Some("differentId"), firstAccountName, Some(amount)),
                 InterestAccountModel(None, secondAccountName, Some(amount), uniqueSessionId = Some(id))
               ))
-            )))
+            ))
             authoriseAgentOrIndividual(us.isAgent)
             urlGet(url(id), us.isWelsh, follow = false, playSessionCookie(us.isAgent))
           }
@@ -187,7 +187,7 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
           lazy val result = {
             dropInterestDB()
             emptyUserDataStub()
-            insertCyaData(Some(InterestCYAModel(Some(true), Some(false), None)))
+            insertCyaData(Some(InterestCYAModel(Some(true), Some(false))))
             authoriseAgentOrIndividual(us.isAgent)
             urlGet(url("id"), us.isWelsh, follow = false, playSessionCookie(us.isAgent))
           }
@@ -207,7 +207,7 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
               userDataStub(IncomeSourcesModel(None, Some(Seq(InterestModel(firstAccountName, id, None, Some(amount)))), None), nino, taxYear)
               insertCyaData(Some(InterestCYAModel(
                 Some(true), Some(false),
-                Some(Seq(InterestAccountModel(Some(id), firstAccountName, Some(amount), None, Some(id))))
+                Seq(InterestAccountModel(Some(id), firstAccountName, Some(amount), None, Some(id)))
               )), taxYear, None, Some(nino))
               authoriseAgentOrIndividual(us.isAgent)
               urlGet(url(id), us.isWelsh, follow = false, playSessionCookie(us.isAgent))
@@ -273,11 +273,11 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
           dropInterestDB()
           emptyUserDataStub()
           insertCyaData(Some(InterestCYAModel(
-            Some(true), Some(false), Some(Seq(
+            Some(true), Some(false), Seq(
               InterestAccountModel(Some("differentId"), firstAccountName, Some(amount)),
               InterestAccountModel(None, secondAccountName, Some(amount), uniqueSessionId = Some(id))
             ))
-          )))
+          ))
           authoriseAgentOrIndividual(us.isAgent)
           urlPost(url(id), formMap, us.isWelsh, follow = false, playSessionCookie(us.isAgent))
         }
@@ -387,11 +387,11 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
             dropInterestDB()
             emptyUserDataStub()
             insertCyaData(Some(InterestCYAModel(
-              Some(true), Some(false), Some(Seq(
+              Some(true), Some(false), Seq(
                 InterestAccountModel(Some("differentId"), firstAccountName, Some(amount)),
                 InterestAccountModel(None, secondAccountName, Some(amount), uniqueSessionId = Some(id))
               ))
-            )))
+            ))
             authoriseAgentOrIndividual(us.isAgent)
             urlPost(url("1234567890-09876543210"), Map(
               UntaxedInterestAmountForm.untaxedAmount -> "12,344.98",
@@ -438,9 +438,9 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
           lazy val result: WSResponse = {
             dropInterestDB()
             userDataStub(IncomeSourcesModel(None, Some(Seq(InterestModel(firstAccountName, id, None, None))), None), nino, taxYear)
-            insertCyaData(Some(InterestCYAModel(Some(true),None,Some(Seq(
+            insertCyaData(Some(InterestCYAModel(Some(true),None,Seq(
               InterestAccountModel(None,"name",Some(1234),uniqueSessionId = Some("1234567890"))
-            )))))
+            ))))
             authoriseAgentOrIndividual(us.isAgent)
             urlPost(url("1234567890"), Map(
               UntaxedInterestAmountForm.untaxedAmount -> "12,344.98",
@@ -460,9 +460,9 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
           lazy val result: WSResponse = {
             dropInterestDB()
             emptyUserDataStub()
-            insertCyaData(Some(InterestCYAModel(Some(true),None,Some(Seq(
+            insertCyaData(Some(InterestCYAModel(Some(true),None,Seq(
               InterestAccountModel(None,"name",Some(1234),Some(1234),uniqueSessionId = Some("1234567890"))
-            )))))
+            ))))
             authoriseAgentOrIndividual(us.isAgent)
             urlPost(url("1234567890"), Map(
               UntaxedInterestAmountForm.untaxedAmount -> "12,344.98",
@@ -476,10 +476,10 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
               "/update-and-submit-income-tax-return/personal-income/2022/interest/accounts-with-untaxed-uk-interest")
 
             val data = findInterestDb
-            data.head shouldBe InterestCYAModel(Some(true),None,Some(List(
-              InterestAccountModel(None,firstAccountName,Some(12344.98),uniqueSessionId = data.head.accounts.get.head.uniqueSessionId),
+            data.head shouldBe InterestCYAModel(Some(true),None,List(
+              InterestAccountModel(None,firstAccountName,Some(12344.98),uniqueSessionId = data.head.accounts.head.uniqueSessionId),
               InterestAccountModel(None,"name",None,Some(1234),uniqueSessionId = Some("1234567890"))
-            )))
+            ))
           }
         }
 
@@ -502,9 +502,9 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
               "/update-and-submit-income-tax-return/personal-income/2022/interest/accounts-with-untaxed-uk-interest")
 
             val data = findInterestDb
-            data shouldBe Some(InterestCYAModel(Some(true),None,Some(Seq(
-              InterestAccountModel(None,firstAccountName,Some(12344.98),uniqueSessionId = data.head.accounts.get.head.uniqueSessionId)
-            ))))
+            data shouldBe Some(InterestCYAModel(Some(true),None,Seq(
+              InterestAccountModel(None,firstAccountName,Some(12344.98),uniqueSessionId = data.head.accounts.head.uniqueSessionId)
+            )))
           }
         }
 

--- a/it/controllers/interest/UntaxedInterestControllerISpec.scala
+++ b/it/controllers/interest/UntaxedInterestControllerISpec.scala
@@ -183,7 +183,7 @@ class UntaxedInterestControllerISpec extends IntegrationTest with InterestDataba
           "there is cya data in session" which {
             val interestCYA = InterestCYAModel(
               Some(true),
-              Some(false),Some(Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(25.00))))
+              Some(false),Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(25.00)))
             )
 
             lazy val result = {
@@ -372,7 +372,7 @@ class UntaxedInterestControllerISpec extends IntegrationTest with InterestDataba
 
             "redirects to INTEREST CYA page when the cya model is finished" when {
               lazy val interestCYA = InterestCYAModel(
-                Some(true), Some(false), Some(Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount))))
+                Some(true), Some(false), Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount)))
               )
 
               lazy val result: WSResponse = {
@@ -435,7 +435,7 @@ class UntaxedInterestControllerISpec extends IntegrationTest with InterestDataba
 
             "redirects to INTEREST CYA page when the cya model is finished" when {
               lazy val interestCYA = InterestCYAModel(
-                Some(true), Some(false),Some(Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount))))
+                Some(true), Some(false), Seq(InterestAccountModel(Some("UntaxedId"), "Untaxed Account", Some(amount)))
               )
 
               lazy val result: WSResponse = {

--- a/it/utils/IntegrationTest.scala
+++ b/it/utils/IntegrationTest.scala
@@ -95,13 +95,13 @@ trait IntegrationTest extends AnyWordSpecLike with Matchers with GuiceOneServerP
   val completeInterestCYAModel: InterestCYAModel = InterestCYAModel(
     untaxedUkInterest = Some(true),
     taxedUkInterest = Some(true),
-    accounts = Some(Seq(InterestAccountModel(
+    accounts = Seq(InterestAccountModel(
       id = Some("id"),
       accountName = "accountName",
       untaxedAmount = Some(50.00),
       taxedAmount = Some(50.00),
       uniqueSessionId = None
-    )))
+    ))
   )
 
   val priorDataMax: GiftAidSubmissionModel = GiftAidSubmissionModel(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -21,7 +21,7 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.19.0",
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "1.31.0-play-28",
+    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "2.0.0-play-28",
     "uk.gov.hmrc"             %% "govuk-template"             % "5.74.0-play-28",
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"         % "0.59.0",
     "com.fasterxml.jackson.module" %% "jackson-module-scala"  % "2.12.5"

--- a/test/audit/CreateOrAmendInterestAuditDetailSpec.scala
+++ b/test/audit/CreateOrAmendInterestAuditDetailSpec.scala
@@ -23,10 +23,10 @@ import utils.UnitTest
 class CreateOrAmendInterestAuditDetailSpec extends UnitTest {
 
   val body = InterestCYAModel(
-    Some(true), Some(true), Some(Seq(
+    Some(true), Some(true), Seq(
       InterestAccountModel(Some("azerty"), "Account 1", Some(100.01)),
       InterestAccountModel(Some("qwerty"), "Account 2", None, Some(9001.01))
-    ))
+    )
   )
 
   val prior = InterestPriorSubmission(

--- a/test/models/interest/EncryptedInterestCYAModelSpec.scala
+++ b/test/models/interest/EncryptedInterestCYAModelSpec.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.interest
+
+import play.api.libs.json.{JsObject, Json}
+import utils.{EncryptedValue, UnitTest}
+
+class EncryptedInterestCYAModelSpec extends UnitTest {
+  val account = EncryptedInterestAccountModel(
+    id = Some(EncryptedValue("someId", "someId-Nonce")),
+    accountName = EncryptedValue("someName", "someName-Nonce"),
+    Some(EncryptedValue("100.00", "100.00-Nonce")),
+    Some(EncryptedValue("100.00", "100.00-Nonce"))
+  )
+
+  val modelMax: EncryptedInterestCYAModel = EncryptedInterestCYAModel(
+    untaxedUkInterest = Some(EncryptedValue("true", "true-Nonce")),
+    taxedUkInterest = Some(EncryptedValue("true", "true-Nonce")),
+    Seq(account)
+  )
+
+  val jsonMax: JsObject = Json.obj(
+    "untaxedUkInterest" -> Json.obj(
+      "value" -> "true",
+      "nonce" -> "true-Nonce"
+    ),
+    "taxedUkInterest" -> Json.obj(
+      "value" -> "true",
+      "nonce" -> "true-Nonce"
+    ),
+    "accounts" -> Json.arr(
+      Json.obj(
+        "id" -> Json.obj(
+          "value" -> "someId",
+          "nonce" -> "someId-Nonce"
+        ),
+        "accountName" -> Json.obj(
+          "value" -> "someName",
+          "nonce" -> "someName-Nonce"
+        ),
+        "untaxedAmount" -> Json.obj(
+          "value" -> "100.00",
+          "nonce" -> "100.00-Nonce"
+        ),
+        "taxedAmount" -> Json.obj(
+          "value" -> "100.00",
+          "nonce" -> "100.00-Nonce"
+        )
+      )
+    )
+  )
+
+  val jsonNoAccounts: JsObject = Json.obj(
+    "untaxedUkInterest" -> Json.obj(
+      "value" -> "true",
+      "nonce" -> "true-Nonce"
+    ),
+    "taxedUkInterest" -> Json.obj(
+      "value" -> "false",
+      "nonce" -> "false-Nonce"
+    )
+  )
+
+  val modelMin: EncryptedInterestCYAModel = EncryptedInterestCYAModel(
+    untaxedUkInterest = None,
+    taxedUkInterest = None,
+    accounts = Seq()
+  )
+
+  val modelNoAccounts: EncryptedInterestCYAModel = EncryptedInterestCYAModel(
+    untaxedUkInterest = Some(EncryptedValue("true", "true-Nonce")),
+    taxedUkInterest = Some(EncryptedValue("false", "false-Nonce"))
+  )
+
+  val jsonMin: JsObject = Json.obj()
+
+  "EncryptedInterestCYAModel" should {
+
+    "correctly parse to json" when {
+
+      "all fields are present" in {
+        Json.toJson(modelMax) shouldBe jsonMax
+      }
+
+      "no fields are present" in {
+        Json.toJson(modelMin) shouldBe jsonMin
+      }
+
+      "accounts not specified" in {
+        Json.toJson(modelNoAccounts) shouldBe jsonNoAccounts
+      }
+    }
+
+    "correctly parse from json" when {
+
+      "all fields are present" in {
+        jsonMax.as[EncryptedInterestCYAModel] shouldBe modelMax
+      }
+
+      "no fields are present" in {
+        jsonMin.as[EncryptedInterestCYAModel] shouldBe modelMin
+      }
+
+      "accounts not specified" in {
+        jsonNoAccounts.as[EncryptedInterestCYAModel] shouldBe modelNoAccounts
+      }
+    }
+
+  }
+}

--- a/test/models/interest/InterestCYAModelSpec.scala
+++ b/test/models/interest/InterestCYAModelSpec.scala
@@ -46,10 +46,20 @@ class InterestCYAModelSpec extends UnitTest {
     )
   )
 
+  val jsonNoAccounts: JsObject = Json.obj(
+    "untaxedUkInterest" -> true,
+    "taxedUkInterest" -> false
+  )
+
   val modelMin: InterestCYAModel = InterestCYAModel(
     untaxedUkInterest = None,
     taxedUkInterest = None,
     accounts = Seq()
+  )
+
+  val modelNoAccounts: InterestCYAModel = InterestCYAModel(
+    untaxedUkInterest = Some(true),
+    taxedUkInterest = Some(false)
   )
 
   val jsonMin: JsObject = Json.obj()
@@ -66,6 +76,9 @@ class InterestCYAModelSpec extends UnitTest {
         Json.toJson(modelMin) shouldBe jsonMin
       }
 
+      "accounts not specified" in {
+        Json.toJson(modelNoAccounts) shouldBe jsonNoAccounts
+      }
     }
 
     "correctly parse from json" when {
@@ -76,6 +89,10 @@ class InterestCYAModelSpec extends UnitTest {
 
       "no fields are present" in {
         jsonMin.as[InterestCYAModel] shouldBe modelMin
+      }
+
+      "accounts not specified" in {
+        jsonNoAccounts.as[InterestCYAModel] shouldBe modelNoAccounts
       }
     }
 

--- a/test/models/interest/InterestCYAModelSpec.scala
+++ b/test/models/interest/InterestCYAModelSpec.scala
@@ -30,7 +30,7 @@ class InterestCYAModelSpec extends UnitTest {
   val modelMax: InterestCYAModel = InterestCYAModel(
     untaxedUkInterest = Some(true),
     taxedUkInterest = Some(true),
-    Some(Seq(account))
+    Seq(account)
   )
 
   val jsonMax: JsObject = Json.obj(
@@ -49,7 +49,7 @@ class InterestCYAModelSpec extends UnitTest {
   val modelMin: InterestCYAModel = InterestCYAModel(
     untaxedUkInterest = None,
     taxedUkInterest = None,
-    accounts = None
+    accounts = Seq()
   )
 
   val jsonMin: JsObject = Json.obj()
@@ -89,7 +89,7 @@ class InterestCYAModelSpec extends UnitTest {
         InterestCYAModel(
           Some(true),
           Some(true),
-          Some(Seq(account.copy(taxedAmount = None)))
+          Seq(account.copy(taxedAmount = None))
         ).isFinished shouldBe false
       }
 
@@ -97,7 +97,7 @@ class InterestCYAModelSpec extends UnitTest {
         InterestCYAModel(
           Some(true),
           Some(true),
-          Some(Seq(account.copy(untaxedAmount = None)))
+          Seq(account.copy(untaxedAmount = None))
         ).isFinished shouldBe false
       }
 
@@ -105,7 +105,7 @@ class InterestCYAModelSpec extends UnitTest {
         InterestCYAModel(
           Some(true),
           Some(true),
-          None
+          Seq()
         ).isFinished shouldBe false
       }
 
@@ -113,7 +113,7 @@ class InterestCYAModelSpec extends UnitTest {
         InterestCYAModel(
           untaxedUkInterest = Some(true),
           taxedUkInterest = None,
-          accounts = Some(Seq(account.copy(taxedAmount = None)))
+          accounts = Seq(account.copy(taxedAmount = None))
         ).isFinished shouldBe false
       }
 
@@ -121,7 +121,7 @@ class InterestCYAModelSpec extends UnitTest {
         InterestCYAModel(
           untaxedUkInterest = None,
           taxedUkInterest = Some(true),
-          accounts = Some(Seq(account.copy(untaxedAmount = None)))
+          accounts = Seq(account.copy(untaxedAmount = None))
         ).isFinished shouldBe false
       }
 
@@ -133,7 +133,7 @@ class InterestCYAModelSpec extends UnitTest {
           InterestCYAModel(
             untaxedUkInterest = Some(true),
             taxedUkInterest = Some(false),
-            accounts = Some(Seq(account.copy(taxedAmount = None)))
+            accounts = Seq(account.copy(taxedAmount = None))
           ).isFinished shouldBe true
         }
 
@@ -141,7 +141,7 @@ class InterestCYAModelSpec extends UnitTest {
         InterestCYAModel(
           untaxedUkInterest = Some(false),
           taxedUkInterest = Some(true),
-          accounts = Some(Seq(account.copy(untaxedAmount = None)))
+          accounts = Seq(account.copy(untaxedAmount = None))
         ).isFinished shouldBe true
       }
     }

--- a/test/services/InterestSubmissionServiceSpec.scala
+++ b/test/services/InterestSubmissionServiceSpec.scala
@@ -43,8 +43,8 @@ class InterestSubmissionServiceSpec extends UnitTest {
       lazy val cyaModel = InterestCYAModel(
         Some(true),
         Some(true),
-        Some(Seq(InterestAccountModel(Some("anId"), "dis account yo", Some(100.00), None, None),
-          InterestAccountModel(Some("anotherId"), "a bank thing", None, Some(200.00), None)))
+        Seq(InterestAccountModel(Some("anId"), "dis account yo", Some(100.00), None, None),
+          InterestAccountModel(Some("anotherId"), "a bank thing", None, Some(200.00), None))
       )
 
       lazy val accounts: Seq[InterestSubmissionModel] = Seq(
@@ -75,7 +75,7 @@ class InterestSubmissionServiceSpec extends UnitTest {
                 Right(NO_CONTENT)
               )
 
-            await(service.submit(cyaModel.copy(Some(false), Some(false), None), "AA123456A", taxYear, "1234567890"))
+            await(service.submit(cyaModel.copy(Some(false), Some(false), Seq()), "AA123456A", taxYear, "1234567890"))
           }
 
           result shouldBe Right(NO_CONTENT)

--- a/test/utils/ViewUtilsSpec.scala
+++ b/test/utils/ViewUtilsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
The `InterestCYAModel` contains a field `accounts` which has the type `Option[Seq[InterestAccountModel]] `

The goal is to change this to a `Seq[InterestAccountModel]` which will simplify the code where we try to access/modify the list of accounts as we will not need to deal with the outer option.

[SASS-1089](https://jira.tools.tax.service.gov.uk/browse/SASS-1089)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of master?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts or any changes in the current master that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [x]  Have you run the tests?
- [x]  Have you run the journey tests? (where applicable)
- [x]  Have you addressed warnings where appropriate?
- [x]  Have you rebased against the current version of master?
- [x]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [X]  Have you checked the PR Builder passes?
