### PR TITLE
SASS-3329: Interest account name containing special characters rejected downstream

### DIFF
--- a/app/forms/validation/StringConstraints.scala
+++ b/app/forms/validation/StringConstraints.scala
@@ -22,7 +22,7 @@ import play.api.data.validation.{Constraint, Invalid, Valid}
 object StringConstraints {
 
   val charRegex = """^([ A-Za-z0-9&@£/.,*’()'-])*$"""
-  val charRegexInterest = """^([ A-Za-z0-9&@£.,*’()'-])*$"""
+  val charRegexInterest = """^([ A-Za-z0-9&.,’'-])*$"""
   val numericalCharacters = """[0-9.]*"""
 
   val monetaryRegex = """\d+|\d*\.\d{1,2}"""

--- a/conf/messages
+++ b/conf/messages
@@ -202,7 +202,7 @@ interest.untaxed-uk-interest-amount.error.empty.agent = Enter the amount of unta
 interest.untaxed-uk-interest-amount.error.invalid-numeric = Enter the amount of untaxed UK interest in the correct format
 interest.untaxed-uk-interest-amount.error.max-amount = The amount of untaxed UK interest must be less than £100,000,000,000
 
-interest.untaxed-uk-interest-details.error.invalidChars = Name of account with untaxed UK interest must only include numbers 0-9, letters a to z, hyphens, spaces, apostrophes, commas, full stops, round brackets, and the special characters &, @, £, *
+interest.untaxed-uk-interest-details.error.invalidChars = Name of account with untaxed UK interest must only include numbers 0-9, letters a to z, hyphens, spaces, apostrophes, commas, full stops and ampersands
 
 interest.untaxed-uk-interest-accounts.title = Accounts with untaxed UK interest
 interest.untaxed-uk-interest-accounts.account.tell-us-about-all.individual = You must tell us about all your accounts with untaxed UK interest.
@@ -219,7 +219,7 @@ interest.taxed-uk-interest.errors.noRadioSelected.individual = Select yes if you
 interest.taxed-uk-interest.errors.noRadioSelected.agent = Select yes if your client got taxed UK interest
 
 interest.taxed-uk-interest-details.title = Add an account with taxed UK interest
-interest.taxed-uk-interest-amount.error.invalidChars = Name of account with taxed UK interest must only include numbers 0-9, letters a to z, hyphens, spaces, apostrophes, commas, full stops, round brackets, and the special characters &, @, £, *
+interest.taxed-uk-interest-amount.error.invalidChars = Name of account with taxed UK interest must only include numbers 0-9, letters a to z, hyphens, spaces, apostrophes, commas, full stops and ampersands
 interest.taxed-uk-interest.amount.interest.earned = Amount of taxed UK interest
 interest.taxed-uk-interest-amount.error.empty.individual = Enter the amount of taxed UK interest you got
 interest.taxed-uk-interest-amount.error.empty.agent = Enter the amount of taxed UK interest your client got

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -202,7 +202,7 @@ interest.untaxed-uk-interest-amount.error.empty.agent = Nodwch swm y llog y DU s
 interest.untaxed-uk-interest-amount.error.invalid-numeric = Nodwch swm y llog y DU sydd heb ei drethu yn y fformat cywir
 interest.untaxed-uk-interest-amount.error.max-amount = Mae’n rhaid i swm y llog y DU sydd heb ei drethu fod yn llai na £100,000,000,000
 
-interest.untaxed-uk-interest-details.error.invalidChars = Mae’n rhaid i enw’r cyfrif sydd â llog y DU sydd heb ei drethu cynnwys rhifau 0-9, llythrennau a i z, cysylltnodau, bylchau, collnodau, comas, atalnodau llawn, cromfachau crwn, a’r cymeriadau arbennig &, @, £, * yn unig
+interest.untaxed-uk-interest-details.error.invalidChars = Rhaid i enw’r cyfrif, sydd â llog y DU heb ei drethu, gynnwys y rhifau 0-9, llythrennau a i z, cysylltnodau, bylchau, collnodau, atalnodau, atalnodau llawn ac ampersands yn unig
 
 interest.untaxed-uk-interest-accounts.title = Cyfrifon sydd â llog y DU sydd heb ei drethu
 interest.untaxed-uk-interest-accounts.account.tell-us-about-all.individual = Mae’n rhaid i chi roi gwybod i ni am eich holl gyfrifon sydd â llog y DU sydd heb ei drethu.
@@ -219,7 +219,7 @@ interest.taxed-uk-interest.errors.noRadioSelected.individual = Dewiswch ‘Iawn�
 interest.taxed-uk-interest.errors.noRadioSelected.agent = Dewiswch ‘Iawn’ os gafodd eich cleient llog y DU a drethwyd
 
 interest.taxed-uk-interest-details.title = Ychwanegwch gyfrif gyda llog y DU a drethwyd
-interest.taxed-uk-interest-amount.error.invalidChars = Mae’n rhaid i enw’r cyfrif sydd â llog y DU a drethwyd cynnwys rhifau 0-9, llythrennau a i z, cysylltnodau, bylchau, collnodau, comas, atalnodau llawn, cromfachau crwn, a’r cymeriadau arbennig &, @, £, * yn unig
+interest.taxed-uk-interest-amount.error.invalidChars = Rhaid i enw’r cyfrif, sydd â llog y DU a drethwyd, gynnwys y rhifau 0-9, llythrennau a i z, cysylltnodau, bylchau, collnodau, atalnodau, atalnodau llawn ac ampersands yn unig
 interest.taxed-uk-interest.amount.interest.earned = Swm y llog y DU a drethwyd
 interest.taxed-uk-interest-amount.error.empty.individual = Nodwch swm y llog y DU a drethwyd a gawsoch
 interest.taxed-uk-interest-amount.error.empty.agent = Nodwch swm y llog y DU a drethwyd a gafodd eich cleient

--- a/it/controllers/interest/TaxedInterestAmountControllerISpec.scala
+++ b/it/controllers/interest/TaxedInterestAmountControllerISpec.scala
@@ -84,7 +84,7 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
     val button: String = "Continue"
     val noNameEntryError: String = "Enter a name for this account"
     val invalidCharEntry: String = "Name of account with taxed UK interest must only include numbers 0-9, " +
-      "letters a to z, hyphens, spaces, apostrophes, commas, full stops, round brackets, and the special characters &, @, £, *"
+      "letters a to z, hyphens, spaces, apostrophes, commas, full stops and ampersands"
     val nameTooLongError: String = "The name of the account must be 32 characters or fewer"
     val duplicateNameError: String = "You cannot add 2 accounts with the same name"
     val tooMuchMoneyError = "The amount of taxed UK interest must be less than £100,000,000,000"
@@ -101,8 +101,8 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
     val hint: String = "Er enghraifft, ‘cyfrif cynilo HSBC’. " + "Er enghraifft, £193.52"
     val button: String = "Yn eich blaen"
     val noNameEntryError: String = "Nodwch enw ar gyfer y cyfrif hwn"
-    val invalidCharEntry: String = "Mae’n rhaid i enw’r cyfrif sydd â llog y DU a drethwyd cynnwys rhifau 0-9, " +
-      "llythrennau a i z, cysylltnodau, bylchau, collnodau, comas, atalnodau llawn, cromfachau crwn, a’r cymeriadau arbennig &, @, £, * yn unig"
+    val invalidCharEntry: String = "Rhaid i enw’r cyfrif, sydd â llog y DU a drethwyd, gynnwys y rhifau 0-9, " +
+      "llythrennau a i z, cysylltnodau, bylchau, collnodau, atalnodau, atalnodau llawn ac ampersands yn unig"
     val nameTooLongError: String = "Mae’n rhaid i enw’r cyfrif fod yn 32 o gymeriadau neu lai"
     val duplicateNameError: String = "Ni allwch ychwanegu 2 gyfrif gyda’r un enw"
     val tooMuchMoneyError = "Mae’n rhaid i swm y llog y DU a drethwyd fod yn llai na £100,000,000,000"
@@ -328,6 +328,78 @@ class TaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelper
         "invalid characters are entered into the fields" should {
           lazy val result = response(Map(TaxedInterestAmountForm.taxedAmount -> "money",
             TaxedInterestAmountForm.taxedAccountName -> "$uper"))
+
+          implicit def document: () => Document = () => Jsoup.parse(result.body)
+
+          s"return a 400(BadRequest) status" in {
+            result.status shouldBe BAD_REQUEST
+          }
+
+          multipleErrorCheck(
+            List(
+              (invalidCharEntry, Selectors.accountNameInput),
+              (incorrectFormatError, Selectors.amountInput)
+            ), us.isWelsh
+          )
+        }
+
+        "round brackets are entered into the account name field" should {
+          lazy val result = response(Map(TaxedInterestAmountForm.taxedAmount -> "money",
+            TaxedInterestAmountForm.taxedAccountName -> "Account (taxed)"))
+
+          implicit def document: () => Document = () => Jsoup.parse(result.body)
+
+          s"return a 400(BadRequest) status" in {
+            result.status shouldBe BAD_REQUEST
+          }
+
+          multipleErrorCheck(
+            List(
+              (invalidCharEntry, Selectors.accountNameInput),
+              (incorrectFormatError, Selectors.amountInput)
+            ), us.isWelsh
+          )
+        }
+
+        "at sign is entered into the account name field" should {
+          lazy val result = response(Map(TaxedInterestAmountForm.taxedAmount -> "money",
+            TaxedInterestAmountForm.taxedAccountName -> "Account @"))
+
+          implicit def document: () => Document = () => Jsoup.parse(result.body)
+
+          s"return a 400(BadRequest) status" in {
+            result.status shouldBe BAD_REQUEST
+          }
+
+          multipleErrorCheck(
+            List(
+              (invalidCharEntry, Selectors.accountNameInput),
+              (incorrectFormatError, Selectors.amountInput)
+            ), us.isWelsh
+          )
+        }
+
+        "pound symbol is entered into the account name field" should {
+          lazy val result = response(Map(TaxedInterestAmountForm.taxedAmount -> "money",
+            TaxedInterestAmountForm.taxedAccountName -> "Account £"))
+
+          implicit def document: () => Document = () => Jsoup.parse(result.body)
+
+          s"return a 400(BadRequest) status" in {
+            result.status shouldBe BAD_REQUEST
+          }
+
+          multipleErrorCheck(
+            List(
+              (invalidCharEntry, Selectors.accountNameInput),
+              (incorrectFormatError, Selectors.amountInput)
+            ), us.isWelsh
+          )
+        }
+
+        "asterisk symbol is entered into the account name field" should {
+          lazy val result = response(Map(TaxedInterestAmountForm.taxedAmount -> "money",
+            TaxedInterestAmountForm.taxedAccountName -> "Account *"))
 
           implicit def document: () => Document = () => Jsoup.parse(result.body)
 

--- a/it/controllers/interest/UntaxedInterestAmountControllerISpec.scala
+++ b/it/controllers/interest/UntaxedInterestAmountControllerISpec.scala
@@ -84,7 +84,7 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
     val button: String = "Continue"
     val noNameEntryError: String = "Enter a name for this account"
     val invalidCharEntry: String = "Name of account with untaxed UK interest must only include numbers 0-9, " +
-      "letters a to z, hyphens, spaces, apostrophes, commas, full stops, round brackets, and the special characters &, @, £, *"
+      "letters a to z, hyphens, spaces, apostrophes, commas, full stops and ampersands"
     val nameTooLongError: String = "The name of the account must be 32 characters or fewer"
     val duplicateNameError: String = "You cannot add 2 accounts with the same name"
     val tooMuchMoneyError = "The amount of untaxed UK interest must be less than £100,000,000,000"
@@ -101,8 +101,8 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
     val hint: String = "Er enghraifft, ‘cyfrif cynilo HSBC’. " + "Er enghraifft, £193.52"
     val button: String = "Yn eich blaen"
     val noNameEntryError: String = "Nodwch enw ar gyfer y cyfrif hwn"
-    val invalidCharEntry: String = "Mae’n rhaid i enw’r cyfrif sydd â llog y DU sydd heb ei drethu cynnwys rhifau 0-9," +
-      " llythrennau a i z, cysylltnodau, bylchau, collnodau, comas, atalnodau llawn, cromfachau crwn, a’r cymeriadau arbennig &, @, £, * yn unig"
+    val invalidCharEntry: String = "Rhaid i enw’r cyfrif, sydd â llog y DU heb ei drethu, gynnwys y rhifau 0-9, " +
+      "llythrennau a i z, cysylltnodau, bylchau, collnodau, atalnodau, atalnodau llawn ac ampersands yn unig"
     val nameTooLongError: String = "Mae’n rhaid i enw’r cyfrif fod yn 32 o gymeriadau neu lai"
     val duplicateNameError: String = "Ni allwch ychwanegu 2 gyfrif gyda’r un enw"
     val tooMuchMoneyError = "Mae’n rhaid i swm y llog y DU sydd heb ei drethu fod yn llai na £100,000,000,000"
@@ -328,6 +328,78 @@ class UntaxedInterestAmountControllerISpec extends IntegrationTest with ViewHelp
         "invalid characters are entered into the fields" should {
           lazy val result = response(Map(UntaxedInterestAmountForm.untaxedAmount -> "money",
             UntaxedInterestAmountForm.untaxedAccountName -> "$uper"))
+
+          implicit def document: () => Document = () => Jsoup.parse(result.body)
+
+          s"return a 400(BadRequest) status" in {
+            result.status shouldBe BAD_REQUEST
+          }
+
+          multipleErrorCheck(
+            List(
+              (invalidCharEntry, Selectors.accountNameInput),
+              (incorrectFormatError, Selectors.amountInput)
+            ), us.isWelsh
+          )
+        }
+
+        "round brackets are entered into the account name field" should {
+          lazy val result = response(Map(UntaxedInterestAmountForm.untaxedAmount -> "money",
+            UntaxedInterestAmountForm.untaxedAccountName -> "Account (untaxed)"))
+
+          implicit def document: () => Document = () => Jsoup.parse(result.body)
+
+          s"return a 400(BadRequest) status" in {
+            result.status shouldBe BAD_REQUEST
+          }
+
+          multipleErrorCheck(
+            List(
+              (invalidCharEntry, Selectors.accountNameInput),
+              (incorrectFormatError, Selectors.amountInput)
+            ), us.isWelsh
+          )
+        }
+
+        "at sign is entered into the account name field" should {
+          lazy val result = response(Map(UntaxedInterestAmountForm.untaxedAmount -> "money",
+            UntaxedInterestAmountForm.untaxedAccountName -> "Account @"))
+
+          implicit def document: () => Document = () => Jsoup.parse(result.body)
+
+          s"return a 400(BadRequest) status" in {
+            result.status shouldBe BAD_REQUEST
+          }
+
+          multipleErrorCheck(
+            List(
+              (invalidCharEntry, Selectors.accountNameInput),
+              (incorrectFormatError, Selectors.amountInput)
+            ), us.isWelsh
+          )
+        }
+
+        "pound symbol is entered into the account name field" should {
+          lazy val result = response(Map(UntaxedInterestAmountForm.untaxedAmount -> "money",
+            UntaxedInterestAmountForm.untaxedAccountName -> "Account £"))
+
+          implicit def document: () => Document = () => Jsoup.parse(result.body)
+
+          s"return a 400(BadRequest) status" in {
+            result.status shouldBe BAD_REQUEST
+          }
+
+          multipleErrorCheck(
+            List(
+              (invalidCharEntry, Selectors.accountNameInput),
+              (incorrectFormatError, Selectors.amountInput)
+            ), us.isWelsh
+          )
+        }
+
+        "asterisk symbol is entered into the account name field" should {
+          lazy val result = response(Map(UntaxedInterestAmountForm.untaxedAmount -> "money",
+            UntaxedInterestAmountForm.untaxedAccountName -> "Account *"))
 
           implicit def document: () => Document = () => Jsoup.parse(result.body)
 

--- a/test/forms/testUtils/StringConstraintsSpec.scala
+++ b/test/forms/testUtils/StringConstraintsSpec.scala
@@ -31,6 +31,8 @@ class StringConstraintsSpec extends Constraints with AnyWordSpecLike with Matche
   val errMsgNoLeadingSpace = "there are leading spaces"
   val errMsgInvalidInt = "contains non numerical chars"
 
+  val desIncomeSourceNameRegex = "^[A-Za-z0-9 \\-,.&']{1,105}$".r
+
   "The StringConstraints.nonEmpty method" when {
 
     "supplied with empty value" should {
@@ -60,7 +62,7 @@ class StringConstraintsSpec extends Constraints with AnyWordSpecLike with Matche
           val lowerCaseAlphabet = ('a' to 'z').mkString
           val upperCaseAlphabet = lowerCaseAlphabet.toUpperCase()
           val oneToNine = (1 to 9).mkString
-          val otherChar = "&@£/()*.,-"
+          val otherChar = "&.,-"
           val space = ""
 
           StringConstraints.validateChar(errMsgInvalidChar)(lowerCaseAlphabet + upperCaseAlphabet + space + oneToNine + otherChar + space) shouldBe Valid
@@ -84,20 +86,26 @@ class StringConstraintsSpec extends Constraints with AnyWordSpecLike with Matche
           val lowerCaseAlphabet = ('a' to 'z').mkString
           val upperCaseAlphabet = lowerCaseAlphabet.toUpperCase()
           val oneToNine = (1 to 9).mkString
-          val otherChar = "&@£()*.,'-"
+          val otherChar = "&.,'-"
           val space = ""
+
+          val regexList = lowerCaseAlphabet + upperCaseAlphabet + space + oneToNine + otherChar + space
+
+          desIncomeSourceNameRegex.pattern.matcher(regexList).matches shouldBe true
 
           StringConstraints.validateChar(
             errMsgInvalidChar,
             charRegexInterest
-          )(lowerCaseAlphabet + upperCaseAlphabet + space + oneToNine + otherChar + space) shouldBe Valid
+          )(regexList) shouldBe Valid
         }
       }
 
       "supplied with a string which contains invalid characters" should {
 
         "return invalid" in {
-          StringConstraints.validateChar(errMsgInvalidChar, charRegexInterest)("!()+{}?^~/") shouldBe Invalid(errMsgInvalidChar)
+          val regexList = "!()+{}?^~/"
+          desIncomeSourceNameRegex.pattern.matcher(regexList).matches shouldBe false
+          StringConstraints.validateChar(errMsgInvalidChar, charRegexInterest)(regexList) shouldBe Invalid(errMsgInvalidChar)
         }
       }
       


### PR DESCRIPTION
### Description
Change validation for interest account name so that the list of allowed characters always passes schema validation downstream.

[SASS-3329](https://jira.tools.tax.service.gov.uk/browse/SASS-3329)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [X]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [ ]  Have you addressed warnings where appropriate?
- [X]  Have you rebased against the current version of main?
- [X]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
