### PR TITLE
[SASS-11597] Add connector to income-tax-session-data µService

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -37,6 +37,7 @@ class FrontendAppConfig @Inject()(servicesConfig: ServicesConfig) extends AppCon
   lazy val interestBaseUrl: String = s"${servicesConfig.getString(ConfigKeys.incomeTaxInterestUrl)}/income-tax-interest"
   lazy val giftAidBaseUrl: String = s"${servicesConfig.getString(ConfigKeys.incomeTaxGiftAidUrl)}/income-tax-gift-aid"
   lazy val incomeTaxSubmissionBEBaseUrl: String = s"${servicesConfig.getString(ConfigKeys.incomeTaxSubmissionUrl)}/income-tax-submission-service"
+  lazy val vcSessionServiceBaseUrl: String = servicesConfig.baseUrl("income-tax-session-data")
 
   def defaultTaxYear: Int = servicesConfig.getInt(ConfigKeys.defaultTaxYear)
 
@@ -131,6 +132,7 @@ trait AppConfig {
   val interestBaseUrl: String
   val giftAidBaseUrl: String
   val incomeTaxSubmissionBEBaseUrl: String
+  def vcSessionServiceBaseUrl: String
 
   def defaultTaxYear: Int
 

--- a/app/connectors/SessionDataConnector.scala
+++ b/app/connectors/SessionDataConnector.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.FrontendAppConfig
+import connectors.ConnectorFailureLogger.FromResultToConnectorFailureLogger
+import connectors.httpParsers.SessionDataHttpParser.{SessionDataResponse, SessionDataResponseReads}
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class SessionDataConnector @Inject()(config: FrontendAppConfig,
+                                     httpClient: HttpClientV2)(implicit ec: ExecutionContext) {
+
+  def getSessionData(implicit hc: HeaderCarrier): Future[SessionDataResponse] =
+    httpClient
+      .get(url"${config.vcSessionServiceBaseUrl}/income-tax-session-data")
+      .execute[SessionDataResponse]
+      .logFailureReason(connectorName = "SessionDataConnector")
+
+}

--- a/app/connectors/httpParsers/SessionDataHttpParser.scala
+++ b/app/connectors/httpParsers/SessionDataHttpParser.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.httpParsers
+
+import models.APIErrorModel
+import models.session.SessionData
+import play.api.http.Status._
+import play.api.libs.json.JsSuccess
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import utils.PagerDutyHelper.PagerDutyKeys._
+import utils.PagerDutyHelper.pagerDutyLog
+
+object SessionDataHttpParser extends APIParser {
+  type SessionDataResponse = Either[APIErrorModel, Option[SessionData]]
+
+  override val parserName: String = "SessionDataHttpParser"
+  override val service: String = "income-tax-session-data"
+
+  implicit object SessionDataResponseReads extends HttpReads[SessionDataResponse] {
+    override def read(method: String, url: String, response: HttpResponse): SessionDataResponse = {
+      response.status match  {
+        case OK =>
+          response.json.validate[SessionData] match {
+            case JsSuccess(parsedModel, _) => Right(Some(parsedModel))
+            case _ => badSuccessJsonFromAPI
+          }
+        case NOT_FOUND | NO_CONTENT =>
+          Right(None)
+        case SERVICE_UNAVAILABLE =>
+          pagerDutyLog(SERVICE_UNAVAILABLE_FROM_API, logMessage(response))
+          handleAPIError(response)
+        case INTERNAL_SERVER_ERROR =>
+          pagerDutyLog(INTERNAL_SERVER_ERROR_FROM_API, logMessage(response))
+          handleAPIError(response)
+        case _ =>
+          pagerDutyLog(UNEXPECTED_RESPONSE_FROM_API, logMessage(response))
+          handleAPIError(response, Some(INTERNAL_SERVER_ERROR))
+      }
+    }
+  }
+}

--- a/app/models/session/SessionData.scala
+++ b/app/models/session/SessionData.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.session
+
+import play.api.libs.json.{Format, Json}
+
+case class SessionData(sessionId: String,
+                       mtditid: String,
+                       nino: String,
+                       utr: Option[String] = None)
+
+object SessionData {
+  implicit val format: Format[SessionData] = Json.format[SessionData]
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -101,6 +101,12 @@ microservice {
       url = "http://localhost:9081"
     }
 
+    income-tax-session-data {
+      protocol = http
+      host     = localhost
+      port     = 30027
+    }
+
     sign-in {
       url = "http://localhost:9949/auth-login-stub/gg-sign-in"
       continueUrl = "http://localhost:9152"

--- a/it/test/connectors/SessionDataConnectorISpec.scala
+++ b/it/test/connectors/SessionDataConnectorISpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import connectors.httpParsers.SessionDataHttpParser.SessionDataResponse
+import models.{APIErrorBodyModel, APIErrorModel, APIErrorsBodyModel}
+import models.session.SessionData
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.{EitherValues, OptionValues}
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Application
+import play.api.http.Status._
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import test.utils.IntegrationTest
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext
+
+class SessionDataConnectorISpec extends IntegrationTest {
+
+  implicit lazy val hc: HeaderCarrier = HeaderCarrier().withExtraHeaders("X-Session-ID" -> sessionId)
+
+  lazy val connector: SessionDataConnector = app.injector.instanceOf[SessionDataConnector]
+
+  val stubGetUrl = s"/income-tax-session-data"
+  val sessionDataResponse: SessionData = SessionData(mtditid = mtditid, nino = nino, sessionId = sessionId)
+
+  override lazy val app: Application =
+    new GuiceApplicationBuilder()
+      .configure("microservice.services.income-tax-session-data.port" -> wiremockPort)
+      .build()
+
+
+  "calling .getSessionData()" should {
+
+    "return session data" when {
+
+      "downstream response is successful and includes valid JSON" in {
+        stubGet(stubGetUrl, OK, Json.toJson(sessionDataResponse).toString())
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result shouldBe Right(Some(sessionDataResponse))
+      }
+    }
+
+    "return None" when {
+
+      "downstream returns NOT_FOUND" in {
+        stubGet(stubGetUrl, NOT_FOUND, "")
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result shouldBe Right(None)
+      }
+
+      "downstream returns NO_CONTENT" in {
+        stubGet(stubGetUrl, NO_CONTENT, "")
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result shouldBe Right(None)
+      }
+    }
+
+    "return Left(error)" when {
+
+      "downstream returns OK but with an invalid response payload" in {
+        stubGet(stubGetUrl, OK, "{}")
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result shouldBe Left(APIErrorModel(INTERNAL_SERVER_ERROR, APIErrorBodyModel("PARSING_ERROR", "Error parsing response from API")))
+      }
+
+      "downstream fails with Internal Error" in {
+        val serviceUnavailableError = APIErrorBodyModel("INTERNAL_SERVER_ERROR", s"Failed to retrieve session with id: $sessionId")
+        stubGet(stubGetUrl, INTERNAL_SERVER_ERROR, Json.toJson(serviceUnavailableError).toString())
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result shouldBe Left(APIErrorModel(INTERNAL_SERVER_ERROR, APIErrorBodyModel("INTERNAL_SERVER_ERROR", s"Failed to retrieve session with id: $sessionId")))
+      }
+
+      "downstream returns SERVICE_UNAVAILABLE" in {
+        val serviceUnavailableError = APIErrorBodyModel("SERVICE_UNAVAILABLE", "Internal Server error")
+        stubGet(stubGetUrl, SERVICE_UNAVAILABLE, Json.toJson(serviceUnavailableError).toString())
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result shouldBe Left(APIErrorModel(SERVICE_UNAVAILABLE, APIErrorBodyModel("SERVICE_UNAVAILABLE", "Internal Server error")))
+      }
+
+      "downstream fails with unknown error" in {
+        val someRandomError = APIErrorBodyModel("TOO_MANY_REQUESTS", s"some random error")
+        stubGet(stubGetUrl, TOO_MANY_REQUESTS, Json.toJson(someRandomError).toString())
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result shouldBe Left(APIErrorModel(INTERNAL_SERVER_ERROR, APIErrorBodyModel("TOO_MANY_REQUESTS", s"some random error")))
+      }
+
+      "downstream fails when there is unexpected response format" in {
+        stubGet(stubGetUrl, TOO_MANY_REQUESTS, Json.toJson("unexpected response").toString())
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result shouldBe Left(APIErrorModel(INTERNAL_SERVER_ERROR, APIErrorBodyModel("PARSING_ERROR", "Error parsing response from API")))
+      }
+    }
+  }
+}

--- a/test/config/MockAppConfig.scala
+++ b/test/config/MockAppConfig.scala
@@ -30,6 +30,7 @@ class MockAppConfig extends AppConfig with MockFactory {
   override val interestBaseUrl: String = "/interest"
   override val giftAidBaseUrl: String = "/giftAid"
   override val incomeTaxSubmissionBEBaseUrl: String = "/incomeTaxSubmissionBaseUrl"
+  override val vcSessionServiceBaseUrl: String = "/incomeTaxSessionData"
 
   override def defaultTaxYear: Int = 2022
 


### PR DESCRIPTION
**Description**
Adds `SessionDataConnector` and ISpec. 

App-Config-Base PR:
- TBC 
